### PR TITLE
ENH: Launch Script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ nosetests.xml
 coverage.xml
 *,cover
 .hypothesis/
+.pytest_cache
 
 # Translations
 *.mo

--- a/bin/lightpath
+++ b/bin/lightpath
@@ -1,0 +1,38 @@
+import argparse
+
+import happi
+import pydm
+from lightpath import LightController
+from lightpath.ui import LightApp
+
+DEVICE_CONFIG = '/reg/g/pcds/pyps/apps/hutch-python/device_config/db.json'
+
+
+def main(db):
+    """
+    Open the lightpath user interface for a configuration file
+
+    Parameters
+    ----------
+    db: str
+        Path to happi JSON database
+    """
+    # Create PyDM Application
+    app = pydm.PyDMApplication()
+    # Create Lightpath UI from provided database
+    lc = LightController(happi.Client(path=db))
+    lp = LightApp(lc)
+    # Execute
+    lp.show()
+    app.exec_()
+
+
+if __name__ == '__main__':
+    # Create ArgumentParser
+    parser = argparse.ArgumentParser(description='Launch the Lightpath UI')
+    parser.add_argument('--db', dest='db', type=str,
+                        help='Path to device configuration. {} by default'
+                             ''.format(DEVICE_CONFIG))
+    # Parse and launch
+    args = parser.parse_args()
+    main(args.db or DEVICE_CONFIG)

--- a/lightpath/tests/test_gui.py
+++ b/lightpath/tests/test_gui.py
@@ -1,3 +1,5 @@
+from distutils.spawn import find_executable
+
 from lightpath.ui import LightApp
 from lightpath.controller import LightController
 
@@ -23,3 +25,8 @@ def test_beampath_controls(lcls_client):
     assert lightapp.rows[0].device.inserted
     lightapp.transmission_adjusted(50)
     assert lightapp.path.minimum_transmission == 0.5
+
+
+def test_lightpath_launch_script():
+    # Check that the executable was installed
+    assert find_executable('lightpath')

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,6 @@ setup(name     = 'lightpath',
       author   = 'SLAC National Accelerator Laboratory',
 
       packages    = find_packages(),
-      include_package_data=True
-
+      include_package_data=True,
+      scripts=['bin/lightpath']
     )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Launch script to show GUI for arbitrary `happi` database.

```bash
lightpath --db PATH_TO_DB
```

I hardcoded in the path where it currently lives as a default. I though about importing this from `hutch_python` but adding a dependency for just a single path seems gratuitous. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #56 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Added test for script packaging
* Tested with real database