### PR TITLE
MAINT: Handle faulty devices

### DIFF
--- a/lightpath/path.py
+++ b/lightpath/path.py
@@ -87,12 +87,12 @@ def find_device_state(device):
         _in, _out = device.inserted, device.removed
         logger.debug("Device %s reporting; IN=%s, OUT=%s",
                      device.name, _in, _out)
+    # Check if this was an error with an EPICS connection
+    except (TimeoutError, DisconnectedError) as exc:
+        logger.warning("Unable to connect to %r", device)
+        logger.debug(exc, exc_info=True)
+        return DeviceState.Disconnected
     except Exception as exc:
-        # Catch DisconnectionError
-        if isinstance(exc, DisconnectedError):
-            logger.warning("Unable to connect to %r", device)
-            return DeviceState.Disconnected
-        # Check if this was an error with an EPICS connection
         logger.exception("Unable to determine device state for %r", device)
         return DeviceState.Error
     # Check state consistency and return proper Enum

--- a/lightpath/path.py
+++ b/lightpath/path.py
@@ -187,6 +187,8 @@ class BeamPath(OphydObject):
                     trans = getattr(device, 'transmission', 1)
                     if trans < self.minimum_transmission:
                         block.append(device)
+                elif dev_state != DeviceState.Removed:
+                    block.append(device)
             except Exception as exc:
                 logger.error('Unable to determine state of %s', device.name)
                 logger.error(exc)

--- a/lightpath/path.py
+++ b/lightpath/path.py
@@ -29,11 +29,42 @@ logger = logging.getLogger(__name__)
 
 
 class DeviceState(enum.Enum):
-    """Description of BeamStates"""
+    """
+    Description of BeamStates
+
+    The standard Inserted, Removed or Unknown have been expanded within
+    this state to help operators diagnose exact reasons for uncertainty in the
+    state of the beamline
+
+    Attributes
+    ----------
+    Removed:
+        Device is removed from the beamline.
+
+    Inserted:
+        Device is inserted into the beamline. This may or may not prevent beam
+        from reaching downstream devices.
+
+    Unknown:
+        Device is reporting neither an inserted or removed state.
+
+    Inconsistent:
+        The device is reporting that is both inserted and removed.
+
+    Disconnected:
+        We were unable to determine the state of the device because one or more
+        of the relevant signals was not available.
+
+    Error:
+        Catch-all state for any errors the device reported when asked for its
+        state that were not simply a failure to communicate with signals
+    """
     Removed = 0
     Inserted = 1
     Unknown = 2
-    Faulted = 3
+    Inconsistent = 3
+    Disconnected = 4
+    Error = 5
 
 
 def find_device_state(device):

--- a/lightpath/path.py
+++ b/lightpath/path.py
@@ -85,6 +85,8 @@ def find_device_state(device):
     # Gather device information
     try:
         _in, _out = device.inserted, device.removed
+        logger.debug("Device %s reporting; IN=%s, OUT=%s",
+                     device.name, _in, _out)
     except Exception as exc:
         # Catch DisconnectionError
         if isinstance(exc, DisconnectedError):

--- a/lightpath/path.py
+++ b/lightpath/path.py
@@ -177,25 +177,20 @@ class BeamPath(OphydObject):
 
             # Find branching devices and store
             # They will be marked as blocking by downstream devices
-            try:
-                dev_state = find_device_state(device)
-                if device in self.branches:
-                    last_branches.append(device)
-                # Find inserted devices
-                elif dev_state == DeviceState.Inserted:
-                    # Ignore devices with low enough transmssion
-                    trans = getattr(device, 'transmission', 1)
-                    if trans < self.minimum_transmission:
-                        block.append(device)
-                elif dev_state != DeviceState.Removed:
+            dev_state = find_device_state(device)
+            if device in self.branches:
+                last_branches.append(device)
+            # Find inserted devices
+            elif dev_state == DeviceState.Inserted:
+                # Ignore devices with low enough transmssion
+                trans = getattr(device, 'transmission', 1)
+                if trans < self.minimum_transmission:
                     block.append(device)
-            except Exception as exc:
-                logger.error('Unable to determine state of %s', device.name)
-                logger.error(exc)
+            # Find unknown and faulted devices
+            elif dev_state != DeviceState.Removed:
                 block.append(device)
-            finally:
-                # Stache our prior device
-                prior = device
+            # Stache our prior device
+            prior = device
 
         return block
 

--- a/lightpath/tests/test_path.py
+++ b/lightpath/tests/test_path.py
@@ -218,14 +218,14 @@ def test_complex_branching(lcls):
 
 known_table = """\
 +-------+--------+----------+----------+---------+
-| Name  | Prefix | Position | Beamline | Removed |
+| Name  | Prefix | Position | Beamline |   State |
 +-------+--------+----------+----------+---------+
-| zero  | zero   |  0.00000 |      TST |    True |
-| one   | one    |  2.00000 |      TST |    True |
-| two   | two    |  9.00000 |      TST |    True |
-| three | three  | 15.00000 |      TST |    True |
-| four  | four   | 16.00000 |      TST |    True |
-| five  | five   | 24.00000 |      TST |    True |
-| six   | six    | 30.00000 |      TST |    True |
+| zero  | zero   |  0.00000 |      TST | Removed |
+| one   | one    |  2.00000 |      TST | Removed |
+| two   | two    |  9.00000 |      TST | Removed |
+| three | three  | 15.00000 |      TST | Removed |
+| four  | four   | 16.00000 |      TST | Removed |
+| five  | five   | 24.00000 |      TST | Removed |
+| six   | six    | 30.00000 |      TST | Removed |
 +-------+--------+----------+----------+---------+
 """

--- a/lightpath/tests/test_path.py
+++ b/lightpath/tests/test_path.py
@@ -97,6 +97,11 @@ def test_single_impediment(path, branch):
     assert branch.incident_devices == []
     assert branch.cleared is False
 
+    # Broken device
+    del path.path[0].status
+    assert find_device_state(path.path[0]) == DeviceState.Faulted
+    assert path.impediment == path.path[0]
+
 
 def test_multiple_insert_beamline(path):
     # Insert two devices

--- a/lightpath/tests/test_path.py
+++ b/lightpath/tests/test_path.py
@@ -1,28 +1,26 @@
 import io
-from types import SimpleNamespace
 
 from unittest.mock import Mock
 from lightpath import BeamPath
 from lightpath.path import find_device_state, DeviceState
-from .conftest import Crystal
+from .conftest import Crystal, Status
 
 
-def test_find_device_state():
-    dev = SimpleNamespace()
+def test_find_device_state(device):
     # In
-    dev.inserted = True
-    dev.removed = False
-    assert find_device_state(dev) == DeviceState.Inserted
+    device.insert()
+    assert find_device_state(device) == DeviceState.Inserted
     # Out
-    dev.removed = True
-    dev.inserted = False
-    assert find_device_state(dev) == DeviceState.Removed
+    device.remove()
+    assert find_device_state(device) == DeviceState.Removed
     # Unknown
-    dev.inserted = True
-    assert find_device_state(dev) == DeviceState.Unknown
+    device.status = Status.unknown
+    assert find_device_state(device) == DeviceState.Unknown
+    # Disconnected
+    device.status = Status.disconnected
     # Error
-    del dev.inserted
-    assert find_device_state(dev) == DeviceState.Faulted
+    del device.status
+    assert find_device_state(device) == DeviceState.Error
 
 
 def test_range(path):
@@ -99,7 +97,7 @@ def test_single_impediment(path, branch):
 
     # Broken device
     del path.path[0].status
-    assert find_device_state(path.path[0]) == DeviceState.Faulted
+    assert find_device_state(path.path[0]) == DeviceState.Error
     assert path.impediment == path.path[0]
 
 

--- a/lightpath/tests/test_path.py
+++ b/lightpath/tests/test_path.py
@@ -1,9 +1,28 @@
 import io
+from types import SimpleNamespace
 
 from unittest.mock import Mock
-
 from lightpath import BeamPath
+from lightpath.path import find_device_state, DeviceState
 from .conftest import Crystal
+
+
+def test_find_device_state():
+    dev = SimpleNamespace()
+    # In
+    dev.inserted = True
+    dev.removed = False
+    assert find_device_state(dev) == DeviceState.Inserted
+    # Out
+    dev.removed = True
+    dev.inserted = False
+    assert find_device_state(dev) == DeviceState.Removed
+    # Unknown
+    dev.inserted = True
+    assert find_device_state(dev) == DeviceState.Unknown
+    # Error
+    del dev.inserted
+    assert find_device_state(dev) == DeviceState.Faulted
 
 
 def test_range(path):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
The `lightpath` wasn't suitably protected against faulty devices. Many of the methods shamelessly called `device.inserted` e.t.c not accepting that these usually involve Channel Access calls that are liable to fail. Now, we only ask for device information in `find_device_state`. This returns a `DeviceState` enum that describes the state. This helps limit the number of Channel Access calls and in turn uniformly handle when these things fail.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #61 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added a test for a broken device
