### PR TITLE
MAINT: DeviceState in UI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,8 +42,6 @@ script:
   # Build docs.
   - |
     if [[ -n "$DOCTR_DEPLOY_ENCRYPTION_KEY_PCDSHUB_LIGHTPATH" && $BUILD_DOCS ]]; then
-      #Install doctr from a custom branch until
-      #https://github.com/drdoctr/doctr/pull/190 is merged.
       pushd docs
       make html
       popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ before_script:
 script:
   - coverage run run_tests.py
   - coverage report -m
+  - flake8 lightpath
   - set -e
   # Build docs.
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,6 @@ install:
   - conda install conda-build anaconda-client
   - conda update -q conda conda-build
   - conda config --append channels pcds-tag
-  - conda config --append channels pydm-dev
-  - conda config --append channels lightsource2-tag
-  - conda config --append channels gsecars
   - conda config --append channels conda-forge
   # Useful for debugging any issues with conda
   - conda info -a

--- a/README.rst
+++ b/README.rst
@@ -24,10 +24,10 @@ Install the most recent tagged build:
 
 .. code::
 
-  conda install lightpath -c pcds-tag -c lightsource2-tag -c conda-forge
+  conda install lightpath -c pcds-tag  -c conda-forge
 
 Install the most recent development build:
 
 .. code::
 
-  conda install lightpath -c pcds-dev -c lightsource2-tag -c conda-forge
+  conda install lightpath -c pcds-dev -c conda-forge

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,3 +5,4 @@ ipython
 matplotlib
 sphinx
 sphinx_rtd_theme
+flake8

--- a/lightpath/tests/test_widgets.py
+++ b/lightpath/tests/test_widgets.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock
 import pytest
 
 import lightpath.ui
+from lightpath.ui.widgets import state_colors
 
 
 @pytest.fixture(scope='function')
@@ -17,6 +18,8 @@ def lightrow(path):
 def test_widget_updates(lightrow):
     # Toggle device to trigger callbacks
     lightrow.device.remove()
+    assert state_colors[0] in lightrow.state_label.styleSheet()
     lightrow.device.insert()
+    assert state_colors[1] in lightrow.state_label.styleSheet()
     # Check that callbacks have been called
     assert lightrow.state_label.setText.called

--- a/lightpath/ui/widgets.py
+++ b/lightpath/ui/widgets.py
@@ -13,6 +13,14 @@ from lightpath.path import find_device_state, DeviceState
 
 logger = logging.getLogger(__name__)
 
+# Define the state colors that correspond to DeviceState
+state_colors = ['rgb(124, 252, 0)',  # Removed
+                'red',  # Inserted
+                'rgb(255, 215, 0)',  # Unknown
+                'rgb(255, 215, 0)',  # Inconsistent
+                'rgb(255, 0, 255)',  # Disconnected
+                'rgb(255, 0, 255)']  # Error
+
 
 class InactiveRow:
     """
@@ -129,16 +137,8 @@ class LightRow(InactiveRow):
         state = find_device_state(self.device)
         # Set label to state description
         self.state_label.setText(state.name)
-        # Set the color of the label
-        if state == DeviceState.Removed:
-            # Neon Green
-            self.state_label.setStyleSheet("QLabel {color : rgb(124,252,0)}")
-        elif state == DeviceState.Inserted:
-            # Red
-            self.state_label.setStyleSheet("QLabel {color : red}")
-        else:
-            # Purple / Pink
-            self.state_label.setStyleSheet("QLabel {color : rgb(255, 215, 0)}")
+        color = state_colors[state.value]
+        self.state_label.setStyleSheet("QLabel {color: %s}" % color)
         # Disable buttons if necessary
         if hasattr(self, 'insert_button'):
             self.insert_button.setEnabled(state != DeviceState.Inserted)

--- a/lightpath/ui/widgets.py
+++ b/lightpath/ui/widgets.py
@@ -2,12 +2,13 @@
 Definitions for Lightpath Widgets
 """
 import logging
-from enum import Enum
 
 from pydm.PyQt.QtCore import Qt
 from pydm.PyQt.QtGui import QPen, QSizePolicy, QHBoxLayout, QWidget, QLabel
 from pydm.PyQt.QtGui import QFont, QSpacerItem, QPushButton
 from pydm.widgets.drawing import PyDMDrawingRectangle
+
+from lightpath.path import find_device_state, DeviceState
 
 
 logger = logging.getLogger(__name__)
@@ -124,27 +125,25 @@ class LightRow(InactiveRow):
         inserted and removed. The color of the label is also adjusted to either
         green or red to quickly
         """
-        states = Enum('states', ('Unknown', 'Inserted', 'Removed', 'Error'))
         # Interpret state
-        try:
-            state = 1 + int(self.device.inserted) + 2*int(self.device.removed)
-        except Exception as exc:
-            logger.error(exc)
-            state = states.Error.value
+        state = find_device_state(self.device)
         # Set label to state description
-        self.state_label.setText(states(state).name)
+        self.state_label.setText(state.name)
         # Set the color of the label
-        if state == states.Removed.value:
+        if state == DeviceState.Removed:
+            # Neon Green
             self.state_label.setStyleSheet("QLabel {color : rgb(124,252,0)}")
-        elif state == states.Unknown.value:
-            self.state_label.setStyleSheet("QLabel {color : rgb(255, 215, 0)}")
-        else:
+        elif state == DeviceState.Inserted:
+            # Red
             self.state_label.setStyleSheet("QLabel {color : red}")
+        else:
+            # Purple / Pink
+            self.state_label.setStyleSheet("QLabel {color : rgb(255, 215, 0)}")
         # Disable buttons if necessary
         if hasattr(self, 'insert_button'):
-            self.insert_button.setEnabled(state != states.Inserted.value)
+            self.insert_button.setEnabled(state != DeviceState.Inserted)
         if hasattr(self, 'remove_button'):
-            self.remove_button.setEnabled(state != states.Removed.value)
+            self.remove_button.setEnabled(state != DeviceState.Removed)
 
     @property
     def widgets(self):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Since the last release of `lightpath` we now summarize the state of every device in a convenient enum `DeviceState`. This change had not made its way up to the UI. Previously we created a custom Enum here by checking `inserted` and `removed`, this is now removed in favor of `find_device_state`.

### CI Changes
We were also using a bunch of varying Conda channels we no longer depend on. Updated both `Travis` and the `README` to show the simpler install. Also added `flake8`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #65 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
 Strengthened existing test

## Screenshots
<img width="732" alt="screen shot 2018-07-09 at 6 03 16 pm" src="https://user-images.githubusercontent.com/25753048/42483750-26f00162-83a4-11e8-8555-c6ae45e20cc1.png">
