### PR TITLE
UI: Row Change

### DIFF
--- a/lightpath/ui/device.ui
+++ b/lightpath/ui/device.ui
@@ -1,0 +1,202 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>620</width>
+    <height>94</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="spacing">
+    <number>5</number>
+   </property>
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="QWidget" name="widget" native="true">
+     <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,0,0,0">
+      <property name="spacing">
+       <number>2</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="PyDMDrawingRectangle" name="indicator">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Expanding">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>45</width>
+          <height>55</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string/>
+        </property>
+        <property name="whatsThis">
+         <string>
+    A widget with a rectangle drawn in it.
+    This class inherits from PyDMDrawing.
+
+    Parameters
+    ----------
+    parent : QWidget
+        The parent widget for the Label
+    init_channel : str, optional
+        The channel to be used by the widget.
+    </string>
+        </property>
+        <property name="penStyle" stdset="0">
+         <enum>Qt::SolidLine</enum>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QWidget" name="device_information" native="true">
+        <layout class="QVBoxLayout" name="verticalLayout_2">
+         <property name="spacing">
+          <number>5</number>
+         </property>
+         <property name="leftMargin">
+          <number>9</number>
+         </property>
+         <property name="topMargin">
+          <number>20</number>
+         </property>
+         <property name="bottomMargin">
+          <number>20</number>
+         </property>
+         <item alignment="Qt::AlignHCenter">
+          <widget class="QLabel" name="name_label">
+           <property name="font">
+            <font>
+             <pointsize>10</pointsize>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>TextLabel</string>
+           </property>
+          </widget>
+         </item>
+         <item alignment="Qt::AlignHCenter">
+          <widget class="QLabel" name="prefix_label">
+           <property name="font">
+            <font>
+             <pointsize>10</pointsize>
+             <italic>true</italic>
+            </font>
+           </property>
+           <property name="text">
+            <string>TextLabel</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item alignment="Qt::AlignHCenter">
+       <widget class="QLabel" name="state_label">
+        <property name="font">
+         <font>
+          <pointsize>10</pointsize>
+          <weight>75</weight>
+          <bold>true</bold>
+         </font>
+        </property>
+        <property name="text">
+         <string>TextLabel</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QWidget" name="widget" native="true">
+        <layout class="QVBoxLayout" name="verticalLayout_3">
+         <item>
+          <widget class="QPushButton" name="insert_button">
+           <property name="font">
+            <font>
+             <pointsize>10</pointsize>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>Insert</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="remove_button">
+           <property name="font">
+            <font>
+             <pointsize>10</pointsize>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>Remove</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QFrame" name="frame">
+     <property name="frameShape">
+      <enum>QFrame::HLine</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Plain</enum>
+     </property>
+     <property name="lineWidth">
+      <number>2</number>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>PyDMDrawingRectangle</class>
+   <extends>QWidget</extends>
+   <header>pydm.widgets.drawing</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/lightpath/ui/gui.py
+++ b/lightpath/ui/gui.py
@@ -8,8 +8,7 @@ from functools import partial
 
 from pydm import Display
 from pydm.PyQt.QtCore import pyqtSlot, Qt
-from pydm.PyQt.QtGui import QSpacerItem, QGridLayout
-
+from pydm.PyQt.QtGui import QVBoxLayout
 
 from .widgets import LightRow
 
@@ -46,9 +45,8 @@ class LightApp(Display):
         self.path = None
         self._lock = threading.Lock()
         # Create empty layout
-        self.lightLayout = QGridLayout()
-        self.lightLayout.setVerticalSpacing(1)
-        self.lightLayout.setHorizontalSpacing(10)
+        self.lightLayout = QVBoxLayout()
+        self.lightLayout.setSpacing(1)
         self.widget_rows.setLayout(self.lightLayout)
 
         # Add destinations
@@ -188,11 +186,8 @@ class LightApp(Display):
                 # Clear our subscribtions
                 for row in self.rows:
                     row.clear_sub()
-                # Clear the widgets
-                for i in reversed(range(self.lightLayout.count())):
-                    old = self.lightLayout.takeAt(i).widget()
-                    if old:
-                        old.deleteLater()
+                    self.lightLayout.removeWidget(row)
+                    row.deleteLater()
                 # Clear subscribed row cache
                 self.rows.clear()
 
@@ -201,19 +196,15 @@ class LightApp(Display):
                 # Cache row to later clear subscriptions
                 self.rows.append(row)
                 # Connect up remove button
-                if hasattr(row, 'remove_button'):
+                if not row.remove_button.isHidden():
                     row.remove_button.clicked.connect(
                                     partial(self.remove, device=row.device))
                 # Connect up insert button
-                if hasattr(row, 'insert_button'):
+                if not row.insert_button.isHidden():
                     row.insert_button.clicked.connect(
                                     partial(self.insert, device=row.device))
-                # Add widgets to layout
-                for j, widget in enumerate(row.widgets):
-                    if isinstance(widget, QSpacerItem):
-                        self.lightLayout.addItem(widget, i, j)
-                    else:
-                        self.lightLayout.addWidget(widget, i, j)
+                # Add widget to layout
+                self.lightLayout.addWidget(row)
         # Initialize interface
         for row in self.rows:
             row.update_state()

--- a/lightpath/ui/widgets.py
+++ b/lightpath/ui/widgets.py
@@ -2,11 +2,9 @@
 Definitions for Lightpath Widgets
 """
 import logging
+import os.path
 
-from pydm.PyQt.QtCore import Qt
-from pydm.PyQt.QtGui import QPen, QSizePolicy, QHBoxLayout, QWidget, QLabel
-from pydm.PyQt.QtGui import QFont, QSpacerItem, QPushButton
-from pydm.widgets.drawing import PyDMDrawingRectangle
+from pydm import Display
 
 from lightpath.path import find_device_state, DeviceState
 
@@ -22,52 +20,32 @@ state_colors = ['rgb(124, 252, 0)',  # Removed
                 'rgb(255, 0, 255)']  # Error
 
 
-class InactiveRow:
+class InactiveRow(Display):
     """
     Inactive row for happi container
     """
-    font = QFont()
-    font.setPointSize(14)
-    # Italic
-    italic = QFont()
-    font.setPointSize(12)
-    italic.setItalic(True)
-    # Bold
-    bold = QFont()
-    bold.setBold(True)
-
     def __init__(self, device, parent=None):
+        super().__init__(parent=parent)
         self.device = device
         # Create labels
-        self.name_label = QLabel(parent=parent)
         self.name_label.setText(device.name)
-        self.name_label.setFont(self.bold)
-        self.prefix_label = QLabel(parent=parent)
-        self.prefix_label.setObjectName('prefix_frame')
         self.prefix_label.setText('({})'.format(device.prefix))
-        self.prefix_label.setFont(self.italic)
-        self.state_label = QLabel('Disconnected', parent=parent)
-        self.state_label.setFont(self.bold)
+        # By default we mark the device as Disconnected
+        self.state_label.setText('Disconnected')
         self.state_label.setStyleSheet("QLabel {color : rgb(255,0,255)}")
-        # Create Beam Indicator
-        self.indicator = PyDMDrawingRectangle(parent=parent)
-        self.indicator.setMinimumSize(45, 55)
-        self.indicator.setSizePolicy(QSizePolicy.Fixed,
-                                     QSizePolicy.Expanding)
-        self.indicator._pen = QPen(Qt.SolidLine)
-        # Spacer
-        self.spacer = QSpacerItem(40, 20)
 
-    @property
-    def widgets(self):
+    def ui_filename(self):
         """
-        Ordered list of widgets to add to designer
+        Name of designer UI file
         """
-        return [self.indicator,
-                self.name_label,
-                self.prefix_label,
-                self.spacer,
-                self.state_label]
+        return 'device.ui'
+
+    def ui_filepath(self):
+        """
+        Full path to :attr:`.ui_filename`
+        """
+        return os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                            self.ui_filename())
 
     def clear_sub(self):
         """
@@ -98,21 +76,12 @@ class LightRow(InactiveRow):
     """
     def __init__(self, device, parent=None):
         super().__init__(device, parent=parent)
-        # Create button widget
-        self.buttons = QWidget(parent=parent)
-        self.button_layout = QHBoxLayout()
-        self.buttons.setLayout(self.button_layout)
         # Create Insert PushButton
-        if hasattr(device, 'insert'):
-            self.insert_button = QPushButton('Insert', parent=parent)
-            self.insert_button.setFont(self.font)
-            self.button_layout.addWidget(self.insert_button)
-            self.button_layout.addItem(QSpacerItem(10, 20))
+        if not hasattr(device, 'insert'):
+            self.insert_button.hide()
         # Create Remove PushButton
-        if hasattr(device, 'remove'):
-            self.remove_button = QPushButton('Remove', parent=parent)
-            self.remove_button.setFont(self.font)
-            self.button_layout.addWidget(self.remove_button)
+        if not hasattr(device, 'remove'):
+            self.remove_button.hide()
         # Subscribe device to state changes
         try:
             # Wait for later to update widget
@@ -144,18 +113,6 @@ class LightRow(InactiveRow):
             self.insert_button.setEnabled(state != DeviceState.Inserted)
         if hasattr(self, 'remove_button'):
             self.remove_button.setEnabled(state != DeviceState.Removed)
-
-    @property
-    def widgets(self):
-        """
-        Ordered list of widgets to add to designer
-        """
-        return [self.indicator,
-                self.name_label,
-                self.prefix_label,
-                self.spacer,
-                self.state_label,
-                self.buttons]
 
     def clear_sub(self):
         """


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Load each row from a preconfigured `.ui` file instead of creating the entire widget in code. This leads to a better separation of "ui" code and actual "lightpath" logic. The overall PR actually adds lines of code, but if you look by making the UI file I was able to delete quite a few lines of actual Python code. The new UI file also makes the following changes. 
* Buttons are stacked vertically
* Prefix and alias are stacked vertically
* Each device is separated by a horizontal line
* Improvements to layout specification to handle different screen sizes

This was going to part of a large PR that included `Typhon` screens but I've gone back and forth too many times on that implementation and chose just to push this snippet as its own entity.


## Screenshots (if appropriate):
<img width="662" alt="screen shot 2018-07-16 at 6 33 04 pm" src="https://user-images.githubusercontent.com/25753048/42791864-81048532-8927-11e8-8b63-b1292a46b225.png">

