### PR TITLE
UI: Beamline

### DIFF
--- a/lightpath/tests/test_widgets.py
+++ b/lightpath/tests/test_widgets.py
@@ -3,8 +3,7 @@ from unittest.mock import Mock
 import pytest
 
 import lightpath.ui
-from lightpath.ui.widgets import state_colors
-
+from lightpath.ui.widgets import state_colors, to_stylesheet_color
 
 @pytest.fixture(scope='function')
 def lightrow(path):
@@ -18,13 +17,15 @@ def lightrow(path):
 def test_widget_updates(lightrow):
     # Toggle device to trigger callbacks
     lightrow.device.remove()
-    assert state_colors[0] in lightrow.state_label.styleSheet()
+    assert (to_stylesheet_color(state_colors[0])
+            in lightrow.state_label.styleSheet())
     assert lightrow.insert_button.isEnabled()
     assert not lightrow.remove_button.isEnabled()
     lightrow.device.insert()
     assert not lightrow.insert_button.isEnabled()
     assert lightrow.remove_button.isEnabled()
-    assert state_colors[1] in lightrow.state_label.styleSheet()
+    assert (to_stylesheet_color(state_colors[1])
+            in lightrow.state_label.styleSheet())
     # Check that callbacks have been called
     assert lightrow.state_label.setText.called
 

--- a/lightpath/tests/test_widgets.py
+++ b/lightpath/tests/test_widgets.py
@@ -5,6 +5,7 @@ import pytest
 import lightpath.ui
 from lightpath.ui.widgets import state_colors, to_stylesheet_color
 
+
 @pytest.fixture(scope='function')
 def lightrow(path):
     # Generate lightpath

--- a/lightpath/ui/device.ui
+++ b/lightpath/ui/device.ui
@@ -6,146 +6,115 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>700</width>
-    <height>100</height>
+    <width>448</width>
+    <height>274</height>
    </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
   </property>
   <property name="minimumSize">
    <size>
-    <width>700</width>
-    <height>100</height>
+    <width>145</width>
+    <height>250</height>
    </size>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
-   <property name="spacing">
-    <number>5</number>
+   <property name="sizeConstraint">
+    <enum>QLayout::SetDefaultConstraint</enum>
    </property>
    <property name="leftMargin">
     <number>0</number>
    </property>
    <property name="topMargin">
-    <number>0</number>
+    <number>5</number>
    </property>
    <property name="rightMargin">
     <number>0</number>
    </property>
    <property name="bottomMargin">
-    <number>0</number>
+    <number>5</number>
    </property>
-   <item>
-    <widget class="QWidget" name="device_layout" native="true">
-     <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,2,1,1">
+   <item alignment="Qt::AlignHCenter">
+    <widget class="QWidget" name="device_information" native="true">
+     <layout class="QVBoxLayout" name="verticalLayout_2" stretch="0,0,0,0">
       <property name="spacing">
-       <number>2</number>
+       <number>5</number>
       </property>
-      <property name="sizeConstraint">
-       <enum>QLayout::SetDefaultConstraint</enum>
+      <property name="leftMargin">
+       <number>5</number>
       </property>
       <property name="topMargin">
-       <number>0</number>
+       <number>5</number>
+      </property>
+      <property name="rightMargin">
+       <number>5</number>
       </property>
       <property name="bottomMargin">
-       <number>0</number>
+       <number>5</number>
       </property>
-      <item>
-       <widget class="PyDMDrawingRectangle" name="indicator">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Expanding">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
+      <item alignment="Qt::AlignHCenter">
+       <widget class="QLabel" name="name_label">
+        <property name="font">
+         <font>
+          <pointsize>10</pointsize>
+          <weight>75</weight>
+          <bold>true</bold>
+          <kerning>true</kerning>
+         </font>
         </property>
-        <property name="minimumSize">
-         <size>
-          <width>45</width>
-          <height>55</height>
-         </size>
+        <property name="text">
+         <string>TextLabel</string>
         </property>
-        <property name="toolTip">
-         <string/>
+        <property name="scaledContents">
+         <bool>false</bool>
         </property>
-        <property name="whatsThis">
-         <string>
-    A widget with a rectangle drawn in it.
-    This class inherits from PyDMDrawing.
-
-    Parameters
-    ----------
-    parent : QWidget
-        The parent widget for the Label
-    init_channel : str, optional
-        The channel to be used by the widget.
-    </string>
-        </property>
-        <property name="penStyle" stdset="0">
-         <enum>Qt::SolidLine</enum>
+        <property name="alignment">
+         <set>Qt::AlignBottom|Qt::AlignHCenter</set>
         </property>
        </widget>
       </item>
-      <item alignment="Qt::AlignVCenter">
-       <widget class="QWidget" name="device_information" native="true">
-        <layout class="QVBoxLayout" name="verticalLayout_2" stretch="0,0">
-         <property name="spacing">
-          <number>5</number>
-         </property>
-         <property name="leftMargin">
-          <number>5</number>
-         </property>
-         <property name="topMargin">
-          <number>9</number>
-         </property>
-         <property name="rightMargin">
-          <number>5</number>
-         </property>
-         <property name="bottomMargin">
-          <number>9</number>
-         </property>
-         <item alignment="Qt::AlignHCenter">
-          <widget class="QLabel" name="name_label">
-           <property name="font">
-            <font>
-             <pointsize>10</pointsize>
-             <weight>75</weight>
-             <bold>true</bold>
-             <kerning>true</kerning>
-            </font>
-           </property>
-           <property name="text">
-            <string>TextLabel</string>
-           </property>
-           <property name="scaledContents">
-            <bool>false</bool>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignBottom|Qt::AlignHCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item alignment="Qt::AlignHCenter">
-          <widget class="QLabel" name="prefix_label">
-           <property name="font">
-            <font>
-             <pointsize>10</pointsize>
-             <italic>true</italic>
-             <kerning>true</kerning>
-            </font>
-           </property>
-           <property name="text">
-            <string>TextLabel</string>
-           </property>
-           <property name="scaledContents">
-            <bool>false</bool>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignBottom|Qt::AlignHCenter</set>
-           </property>
-          </widget>
-         </item>
-        </layout>
+      <item alignment="Qt::AlignHCenter">
+       <widget class="QLabel" name="prefix_label">
+        <property name="font">
+         <font>
+          <pointsize>10</pointsize>
+          <italic>true</italic>
+          <kerning>true</kerning>
+         </font>
+        </property>
+        <property name="text">
+         <string>TextLabel</string>
+        </property>
+        <property name="scaledContents">
+         <bool>false</bool>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignBottom|Qt::AlignHCenter</set>
+        </property>
        </widget>
+      </item>
+      <item>
+       <spacer name="verticalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeType">
+         <enum>QSizePolicy::Fixed</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>15</height>
+         </size>
+        </property>
+       </spacer>
       </item>
       <item alignment="Qt::AlignHCenter">
        <widget class="QLabel" name="state_label">
@@ -164,116 +133,301 @@
         </property>
        </widget>
       </item>
+     </layout>
+    </widget>
+   </item>
+   <item alignment="Qt::AlignHCenter">
+    <widget class="QWidget" name="horizontalWidget" native="true">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,0,0">
+      <property name="sizeConstraint">
+       <enum>QLayout::SetDefaultConstraint</enum>
+      </property>
+      <property name="bottomMargin">
+       <number>5</number>
+      </property>
       <item>
-       <widget class="QFrame" name="button_frame">
-        <layout class="QVBoxLayout" name="button_frame_layout" stretch="0,0">
-         <property name="spacing">
-          <number>5</number>
-         </property>
-         <property name="sizeConstraint">
-          <enum>QLayout::SetDefaultConstraint</enum>
-         </property>
-         <property name="leftMargin">
-          <number>1</number>
-         </property>
-         <item alignment="Qt::AlignHCenter">
-          <widget class="QLabel" name="label">
-           <property name="font">
-            <font>
-             <weight>75</weight>
-             <bold>true</bold>
-            </font>
-           </property>
-           <property name="text">
-            <string>Available Commands</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <layout class="QHBoxLayout" name="button_layout">
-           <property name="sizeConstraint">
-            <enum>QLayout::SetDefaultConstraint</enum>
-           </property>
-           <item>
-            <widget class="QPushButton" name="insert_button">
-             <property name="enabled">
-              <bool>false</bool>
-             </property>
-             <property name="minimumSize">
-              <size>
-               <width>125</width>
-               <height>0</height>
-              </size>
-             </property>
-             <property name="font">
-              <font>
-               <pointsize>10</pointsize>
-               <weight>75</weight>
-               <bold>true</bold>
-              </font>
-             </property>
-             <property name="text">
-              <string>Insert</string>
-             </property>
-             <property name="checkable">
-              <bool>false</bool>
-             </property>
-             <property name="checked">
-              <bool>false</bool>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QPushButton" name="remove_button">
-             <property name="enabled">
-              <bool>false</bool>
-             </property>
-             <property name="minimumSize">
-              <size>
-               <width>125</width>
-               <height>0</height>
-              </size>
-             </property>
-             <property name="font">
-              <font>
-               <pointsize>10</pointsize>
-               <weight>75</weight>
-               <bold>true</bold>
-              </font>
-             </property>
-             <property name="text">
-              <string>Remove</string>
-             </property>
-             <property name="checkable">
-              <bool>false</bool>
-             </property>
-             <property name="checked">
-              <bool>false</bool>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-        </layout>
+       <widget class="PyDMDrawingRectangle" name="beam_indicator">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>15</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>50</width>
+          <height>15</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string/>
+        </property>
+        <property name="whatsThis">
+         <string>
+    A widget with a rectangle drawn in it.
+    This class inherits from PyDMDrawing.
+
+    Parameters
+    ----------
+    parent : QWidget
+        The parent widget for the Label
+    init_channel : str, optional
+        The channel to be used by the widget.
+    </string>
+        </property>
+        <property name="brush" stdset="0">
+         <brush brushstyle="SolidPattern">
+          <color alpha="255">
+           <red>185</red>
+           <green>185</green>
+           <blue>185</blue>
+          </color>
+         </brush>
+        </property>
+        <property name="penStyle" stdset="0">
+         <enum>Qt::SolidLine</enum>
+        </property>
+        <property name="penWidth" stdset="0">
+         <double>2.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item alignment="Qt::AlignHCenter">
+       <widget class="PyDMDrawingRectangle" name="device_drawing">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>50</width>
+          <height>50</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>50</width>
+          <height>50</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string/>
+        </property>
+        <property name="whatsThis">
+         <string>
+    A widget with a rectangle drawn in it.
+    This class inherits from PyDMDrawing.
+
+    Parameters
+    ----------
+    parent : QWidget
+        The parent widget for the Label
+    init_channel : str, optional
+        The channel to be used by the widget.
+    </string>
+        </property>
+        <property name="brush" stdset="0">
+         <brush brushstyle="SolidPattern">
+          <color alpha="255">
+           <red>185</red>
+           <green>185</green>
+           <blue>185</blue>
+          </color>
+         </brush>
+        </property>
+        <property name="penStyle" stdset="0">
+         <enum>Qt::SolidLine</enum>
+        </property>
+        <property name="penColor" stdset="0">
+         <color>
+          <red>0</red>
+          <green>0</green>
+          <blue>0</blue>
+         </color>
+        </property>
+        <property name="penWidth" stdset="0">
+         <double>2.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="PyDMDrawingRectangle" name="out_indicator">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>50</width>
+          <height>15</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string/>
+        </property>
+        <property name="whatsThis">
+         <string>
+    A widget with a rectangle drawn in it.
+    This class inherits from PyDMDrawing.
+
+    Parameters
+    ----------
+    parent : QWidget
+        The parent widget for the Label
+    init_channel : str, optional
+        The channel to be used by the widget.
+    </string>
+        </property>
+        <property name="brush" stdset="0">
+         <brush brushstyle="SolidPattern">
+          <color alpha="255">
+           <red>185</red>
+           <green>185</green>
+           <blue>185</blue>
+          </color>
+         </brush>
+        </property>
+        <property name="penStyle" stdset="0">
+         <enum>Qt::SolidLine</enum>
+        </property>
+        <property name="penWidth" stdset="0">
+         <double>2.000000000000000</double>
+        </property>
        </widget>
       </item>
      </layout>
     </widget>
    </item>
-   <item>
-    <widget class="QFrame" name="frame">
-     <property name="frameShape">
-      <enum>QFrame::HLine</enum>
-     </property>
-     <property name="frameShadow">
-      <enum>QFrame::Plain</enum>
-     </property>
-     <property name="lineWidth">
-      <number>2</number>
-     </property>
+   <item alignment="Qt::AlignHCenter">
+    <widget class="QWidget" name="widget" native="true">
+     <layout class="QVBoxLayout" name="command_layout">
+      <property name="leftMargin">
+       <number>5</number>
+      </property>
+      <property name="topMargin">
+       <number>5</number>
+      </property>
+      <property name="rightMargin">
+       <number>5</number>
+      </property>
+      <property name="bottomMargin">
+       <number>5</number>
+      </property>
+      <item>
+       <widget class="QLabel" name="label">
+        <property name="font">
+         <font>
+          <weight>75</weight>
+          <bold>true</bold>
+         </font>
+        </property>
+        <property name="text">
+         <string>Available Commands</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="insert_button">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>125</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="font">
+         <font>
+          <pointsize>10</pointsize>
+          <weight>75</weight>
+          <bold>true</bold>
+         </font>
+        </property>
+        <property name="text">
+         <string>Insert</string>
+        </property>
+        <property name="checkable">
+         <bool>false</bool>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="remove_button">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>125</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="font">
+         <font>
+          <pointsize>10</pointsize>
+          <weight>75</weight>
+          <bold>true</bold>
+         </font>
+        </property>
+        <property name="text">
+         <string>Remove</string>
+        </property>
+        <property name="checkable">
+         <bool>false</bool>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
   </layout>

--- a/lightpath/ui/gui.py
+++ b/lightpath/ui/gui.py
@@ -200,12 +200,20 @@ class LightApp(Display):
             for row in self.rows:
                 # If our device is before or at the impediment, it is lit
                 if not block or (row.device.md.z <= block.md.z):
-                    row.indicator._default_color = Qt.cyan
+                    # This device is being hit by the beam
+                    row.beam_indicator._default_color = Qt.cyan
+                    # Check whether this device is passing beam
+                    if block != row.device:
+                        row.out_indicator._default_color = Qt.cyan
+                    else:
+                        row.out_indicator._default_color = Qt.gray
                 # Otherwise, it is off
                 else:
-                    row.indicator._default_color = Qt.gray
+                    row.beam_indicator._default_color = Qt.gray
+                    row.out_indicator._default_color = Qt.gray
                 # Update widget display
-                row.indicator.update()
+                row.beam_indicator.update()
+                row.out_indicator.update()
 
     def clear_subs(self):
         """

--- a/lightpath/ui/gui.py
+++ b/lightpath/ui/gui.py
@@ -7,7 +7,7 @@ import os.path
 
 from pydm import Display
 from pydm.PyQt.QtCore import pyqtSlot, Qt
-from pydm.PyQt.QtGui import QVBoxLayout
+from pydm.PyQt.QtGui import QHBoxLayout
 
 from .widgets import LightRow
 
@@ -44,7 +44,7 @@ class LightApp(Display):
         self.path = None
         self._lock = threading.Lock()
         # Create empty layout
-        self.lightLayout = QVBoxLayout()
+        self.lightLayout = QHBoxLayout()
         self.lightLayout.setSpacing(1)
         self.widget_rows.setLayout(self.lightLayout)
 

--- a/lightpath/ui/widgets.py
+++ b/lightpath/ui/widgets.py
@@ -133,7 +133,10 @@ class LightRow(InactiveRow):
         # Set label to state description
         self.state_label.setText(state.name)
         color = state_colors[state.value]
-        self.state_label.setStyleSheet("QLabel {color: %s}" % color)
+        style_color = to_stylesheet_color(color)
+        self.state_label.setStyleSheet("QLabel {color: %s}" % style_color)
+        self.device_drawing._default_color = color
+        self.device_drawing.update()
         # Disable buttons if necessary
         self.insert_button.setEnabled((state != DeviceState.Inserted
                                        and hasattr(self.device, 'insert')))

--- a/lightpath/ui/widgets.py
+++ b/lightpath/ui/widgets.py
@@ -6,6 +6,7 @@ import os.path
 
 from pydm import Display
 from pydm.PyQt.QtCore import pyqtSlot
+from pydm.PyQt.QtGui import QColor
 
 from lightpath.path import find_device_state, DeviceState
 
@@ -13,12 +14,19 @@ from lightpath.path import find_device_state, DeviceState
 logger = logging.getLogger(__name__)
 
 # Define the state colors that correspond to DeviceState
-state_colors = ['rgb(124, 252, 0)',  # Removed
-                'red',  # Inserted
-                'rgb(255, 215, 0)',  # Unknown
-                'rgb(255, 215, 0)',  # Inconsistent
-                'rgb(255, 0, 255)',  # Disconnected
-                'rgb(255, 0, 255)']  # Error
+state_colors = [QColor(124, 252, 0),  # Removed
+                QColor(255, 0, 0),  # Inserted
+                QColor(255, 215, 0),  # Unknown
+                QColor(255, 215, 0),  # Disconnected
+                QColor(255, 0, 255),  # Disconnected
+                QColor(255, 0, 255)]  # Error
+
+
+def to_stylesheet_color(color):
+    """Utility to convert QColor to stylesheet specification"""
+    return 'rgb({!r}, {!r}, {!r})'.format(color.red(),
+                                          color.green(),
+                                          color.blue())
 
 
 class InactiveRow(Display):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Part of the transformation to making the UI look more like the old system. We now create a mock "drawing" of the beamline that lights up according to the device state and whether the beam is being transmitted or not.


## Screenshots (if appropriate):
<img width="1164" alt="screen shot 2018-07-18 at 2 44 47 pm" src="https://user-images.githubusercontent.com/25753048/42909481-27f25398-8a99-11e8-8831-4dfa5deade0f.png">

