### PR TITLE
ENH: Filter Options

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -17,9 +17,11 @@ requirements:
       - coloredlogs
       - ophyd
       - happi
+      - numpy
+      - prettytable
+      - pcdsdevices
       - pydm
       - pyqt >=5 
-      - prettytable
 
 test:
     imports:

--- a/lightpath/tests/test_gui.py
+++ b/lightpath/tests/test_gui.py
@@ -26,9 +26,16 @@ def test_lightpath_launch_script():
 def test_focus_on_device(lcls_client, monkeypatch):
     lightapp = LightApp(LightController(lcls_client))
     row = lightapp.rows[8]
-    monkeypatch.setattr(row, 'setFocus', Mock())
+    monkeypatch.setattr(lightapp.scroll,
+                        'ensureWidgetVisible',
+                        Mock())
     # Grab the focus
-    lightapp.focus_on_device(row.device.name)
-    assert row.setFocus.called
+    lightapp.focus_on_device(name=row.device.name)
+    lightapp.scroll.ensureWidgetVisible.assert_called_with(row)
+    # Go to impediment if no device is provided
+    first_row = lightapp.rows[0]
+    first_row.insert()
+    lightapp.focus_on_device()
+    lightapp.scroll.ensureWidgetVisible.assert_called_with(first_row)
     # Smoke test a bad device string
     lightapp.focus_on_device('blah')

--- a/lightpath/tests/test_gui.py
+++ b/lightpath/tests/test_gui.py
@@ -8,8 +8,6 @@ from lightpath.tests.conftest import Crystal
 
 def test_app_buttons(lcls_client):
     lightapp = LightApp(LightController(lcls_client))
-    # Check we initialized correctly
-    assert lightapp.upstream()
     # Create widgets
     assert len(lightapp.select_devices('MEC')) == 10
     # Setup new display

--- a/lightpath/tests/test_gui.py
+++ b/lightpath/tests/test_gui.py
@@ -17,12 +17,6 @@ def test_app_buttons(lcls_client):
     assert len(lightapp.rows) == 10
 
 
-def test_beampath_controls(lcls_client):
-    lightapp = LightApp(LightController(lcls_client))
-    lightapp.transmission_adjusted(50)
-    assert lightapp.path.minimum_transmission == 0.5
-
-
 def test_lightpath_launch_script():
     # Check that the executable was installed
     assert find_executable('lightpath')

--- a/lightpath/tests/test_gui.py
+++ b/lightpath/tests/test_gui.py
@@ -1,3 +1,4 @@
+from unittest.mock import Mock
 from distutils.spawn import find_executable
 
 from lightpath.ui import LightApp
@@ -20,3 +21,14 @@ def test_app_buttons(lcls_client):
 def test_lightpath_launch_script():
     # Check that the executable was installed
     assert find_executable('lightpath')
+
+
+def test_focus_on_device(lcls_client, monkeypatch):
+    lightapp = LightApp(LightController(lcls_client))
+    row = lightapp.rows[8]
+    monkeypatch.setattr(row, 'setFocus', Mock())
+    # Grab the focus
+    lightapp.focus_on_device(row.device.name)
+    assert row.setFocus.called
+    # Smoke test a bad device string
+    lightapp.focus_on_device('blah')

--- a/lightpath/tests/test_gui.py
+++ b/lightpath/tests/test_gui.py
@@ -43,22 +43,22 @@ def test_focus_on_device(lcls_client, monkeypatch):
 def test_filtering(lcls_client, monkeypatch):
     lightapp = LightApp(LightController(lcls_client))
     monkeypatch.setattr(LightRow,
-                        'setHidden',
+                        'setVisible',
                         Mock())
     # Hide Crystal devices
     lightapp.show_devicetype(False, Crystal)
     for row in lightapp.rows:
         if isinstance(row.device, Crystal):
-            row.setHidden.assert_called_with(True)
+            row.setVisible.assert_called_with(False)
     # Show Crystal devices
     lightapp.show_devicetype(True, Crystal)
     for row in lightapp.rows:
         if isinstance(row.device, Crystal):
-            row.setHidden.assert_called_with(False)
+            row.setVisible.assert_called_with(True)
     # Insert at least one device then hide
     device_row = lightapp.rows[2]
     device_row.device.insert()
     lightapp.show_removed(False)
     for row in lightapp.rows:
         if row.device.inserted:
-            row.setHidden.assert_called_with(True)
+            row.setVisible.assert_called_with(False)

--- a/lightpath/tests/test_gui.py
+++ b/lightpath/tests/test_gui.py
@@ -62,3 +62,9 @@ def test_filtering(lcls_client, monkeypatch):
     for row in lightapp.rows:
         if row.device.inserted:
             row.setVisible.assert_called_with(False)
+    # Hide upstream devices
+    lightapp.select_devices('MEC')
+    lightapp.show_upstream(False)
+    for row in lightapp.rows:
+        if row.device.md.beamline != 'MEC':
+            row.setVisible.assert_called_with(False)

--- a/lightpath/ui/gui.py
+++ b/lightpath/ui/gui.py
@@ -8,6 +8,7 @@ import os.path
 
 import numpy as np
 import pcdsdevices.device_types as dtypes
+from pcdsdevices.valve import PPSStopper
 from pydm import Display
 from pydm.PyQt.QtCore import pyqtSlot, Qt
 from pydm.PyQt.QtGui import QHBoxLayout, QGridLayout, QCheckBox
@@ -39,10 +40,10 @@ class LightApp(Display):
 
     parent : optional
     """
-    shown_types = [dtypes.Attenuator, dtypes.IPM, dtypes.XFLS,
-                   dtypes.LODCM, dtypes.OffsetMirror, dtypes.PIM,
+    shown_types = [dtypes.Attenuator, dtypes.GateValve, dtypes.IPM,
+                   dtypes.LODCM, dtypes.OffsetMirror, dtypes.PIM, PPSStopper,
                    dtypes.PulsePicker, dtypes.Slits, dtypes.Stopper,
-                   dtypes.GateValve]
+                   dtypes.XFLS]
 
     def __init__(self, controller, beamline=None,
                  parent=None, dark=True):

--- a/lightpath/ui/gui.py
+++ b/lightpath/ui/gui.py
@@ -238,19 +238,18 @@ class LightApp(Display):
                          name)
             return
         # Grab widget
-        self.scroll.ensureWidgetVisible(self.rows[idx])
         self.rows[idx].setHidden(False)
+        self.scroll.ensureWidgetVisible(self.rows[idx])
 
     @pyqtSlot(bool)
     def show_devicetype(self, show, device):
         """Show or hide all instances of a specific row"""
-        return self._filter(show, lambda x: type(x.device) == device)
+        self._filter(show, lambda x: type(x.device) == device)
 
     @pyqtSlot(bool)
     def show_removed(self, show):
         """Show or hide all instances of a specific device"""
-        return self._filter(show,
-                            lambda x: x.last_state == DeviceState.Removed)
+        self._filter(show, lambda x: x.last_state == DeviceState.Removed)
 
     @pyqtSlot(bool)
     def show_upstream(self, show):

--- a/lightpath/ui/gui.py
+++ b/lightpath/ui/gui.py
@@ -251,6 +251,7 @@ class LightApp(Display):
             return
         # Grab widget
         self.scroll.ensureWidgetVisible(self.rows[idx])
+        self.rows[idx].setHidden(False)
 
     @pyqtSlot(bool)
     def show_devicetype(self, show, device):

--- a/lightpath/ui/gui.py
+++ b/lightpath/ui/gui.py
@@ -164,6 +164,12 @@ class LightApp(Display):
                 self.rows.clear()
                 self.device_combo.clear()
 
+            # Hide nothing when switching beamlines
+            boxes = self.device_types.children()
+            boxes.extend([self.upstream_check, self.remove_check])
+            for box in boxes:
+                if isinstance(box, QCheckBox):
+                    box.setChecked(True)
             # Add all the widgets to the display
             for i, row in enumerate(rows):
                 # Cache row to later clear subscriptions

--- a/lightpath/ui/gui.py
+++ b/lightpath/ui/gui.py
@@ -204,6 +204,21 @@ class LightApp(Display):
                 row.beam_indicator.update()
                 row.out_indicator.update()
 
+    @pyqtSlot(str)
+    def focus_on_device(self, name):
+        """Scroll to the desired device"""
+        # Map of names
+        names = [row.device.name for row in self.rows]
+        # Find index
+        try:
+            idx = names.index(name)
+        except ValueError:
+            logger.error("%r is not a visibile device",
+                         name)
+            return
+        # Grab widget
+        self.rows[idx].setFocus()
+
     def clear_subs(self):
         """
         Clear the subscription event

--- a/lightpath/ui/gui.py
+++ b/lightpath/ui/gui.py
@@ -7,7 +7,7 @@ import threading
 import os.path
 
 import numpy as np
-from pcdsdevices.device_types import *  # noqa
+import pcdsdevices.device_types as dtypes
 from pydm import Display
 from pydm.PyQt.QtCore import pyqtSlot, Qt
 from pydm.PyQt.QtGui import QHBoxLayout, QGridLayout, QCheckBox
@@ -39,8 +39,10 @@ class LightApp(Display):
 
     parent : optional
     """
-    shown_types = [Attenuator, IPM, XFLS, LODCM, OffsetMirror, PIM,  # noqa
-                   PulsePicker, Slits, Stopper, GateValve]  # noqa
+    shown_types = [dtypes.Attenuator, dtypes.IPM, dtypes.XFLS,
+                   dtypes.LODCM, dtypes.OffsetMirror, dtypes.PIM,
+                   dtypes.PulsePicker, dtypes.Slits, dtypes.Stopper,
+                   dtypes.GateValve]
 
     def __init__(self, controller, beamline=None,
                  parent=None, dark=True):

--- a/lightpath/ui/gui.py
+++ b/lightpath/ui/gui.py
@@ -56,8 +56,6 @@ class LightApp(Display):
         self.destination_combo.currentIndexChanged.connect(
                                             self.change_path_display)
         self.upstream_check.clicked.connect(self.change_path_display)
-        self.transmission_slider.valueChanged.connect(
-                                          self.transmission_adjusted)
         # Store LightRow objects to manage subscriptions
         self.rows = list()
         # Select the beamline to begin with
@@ -135,15 +133,6 @@ class LightApp(Display):
         """
         return self.upstream_check.isChecked()
 
-    @pyqtSlot(int)
-    def transmission_adjusted(self, value):
-        """
-        Adjust the :attr:`.BeamPath.minimum_transmission`
-        """
-        logger.debug("Adjusted minimum transmission to %s percent", value)
-        self.path.minimum_transmission = value/100.
-        self.update_path()
-
     @pyqtSlot()
     @pyqtSlot(bool)
     def change_path_display(self, value=None):
@@ -175,8 +164,8 @@ class LightApp(Display):
         # Initialize interface
         for row in self.rows:
             row.update_state()
-        # Update display
-        self.transmission_adjusted(self.transmission_slider.value())
+        # Update the state of the path
+        self.update_path()
 
     def ui_filename(self):
         """

--- a/lightpath/ui/gui.py
+++ b/lightpath/ui/gui.py
@@ -7,7 +7,7 @@ import threading
 import os.path
 
 import numpy as np
-from pcdsdevices.device_types import *
+from pcdsdevices.device_types import *  # noqa
 from pydm import Display
 from pydm.PyQt.QtCore import pyqtSlot, Qt
 from pydm.PyQt.QtGui import QHBoxLayout, QGridLayout, QCheckBox
@@ -39,8 +39,9 @@ class LightApp(Display):
 
     parent : optional
     """
-    shown_types = [Attenuator, IPM, XFLS, LODCM, OffsetMirror, PIM,
-                   PulsePicker, Slits, Stopper, GateValve]
+    shown_types = [Attenuator, IPM, XFLS, LODCM, OffsetMirror, PIM,  # noqa
+                   PulsePicker, Slits, Stopper, GateValve]  # noqa
+
     def __init__(self, controller, beamline=None,
                  parent=None, dark=True):
         super().__init__(parent=parent)

--- a/lightpath/ui/gui.py
+++ b/lightpath/ui/gui.py
@@ -221,8 +221,7 @@ class LightApp(Display):
     def focus_on_device(self, name=None):
         """Scroll to the desired device"""
         # If not provided a name, use the impediment
-        if not name and self.path.impediment:
-            name = self.path.impediment.name
+        name = name or self.current_impediment.text()
         # Map of names
         names = [row.device.name for row in self.rows]
         # Find index

--- a/lightpath/ui/gui.py
+++ b/lightpath/ui/gui.py
@@ -142,12 +142,6 @@ class LightApp(Display):
         """
         return self.destination_combo.currentText()
 
-    def upstream(self):
-        """
-        Whether the user has selected to display upstream devices
-        """
-        return self.upstream_check.isChecked()
-
     @pyqtSlot()
     @pyqtSlot(bool)
     def change_path_display(self, value=None):

--- a/lightpath/ui/gui.py
+++ b/lightpath/ui/gui.py
@@ -267,7 +267,7 @@ class LightApp(Display):
         """Helper function to hide a device based on a condition"""
         for row in self.rows:
             if func(row):
-                row.setHidden(not show)
+                row.setVisible(show)
 
     def clear_subs(self):
         """

--- a/lightpath/ui/gui.py
+++ b/lightpath/ui/gui.py
@@ -213,7 +213,7 @@ class LightApp(Display):
         try:
             idx = names.index(name)
         except ValueError:
-            logger.error("%r is not a visibile device",
+            logger.error("Can not set focus on device %r",
                          name)
             return
         # Grab widget

--- a/lightpath/ui/lightapp.ui
+++ b/lightpath/ui/lightapp.ui
@@ -108,12 +108,12 @@
       </layout>
      </item>
      <item>
-      <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="1,2,0">
+      <layout class="QHBoxLayout" name="impediment" stretch="1,2,0">
        <property name="bottomMargin">
         <number>0</number>
        </property>
        <item>
-        <widget class="QLabel" name="label">
+        <widget class="QLabel" name="impediment_label">
          <property name="font">
           <font>
            <weight>75</weight>
@@ -126,7 +126,7 @@
         </widget>
        </item>
        <item>
-        <widget class="QLabel" name="label_2">
+        <widget class="QLabel" name="current_impediment">
          <property name="autoFillBackground">
           <bool>true</bool>
          </property>
@@ -139,7 +139,13 @@
         </widget>
        </item>
        <item>
-        <widget class="QPushButton" name="pushButton">
+        <widget class="QPushButton" name="impediment_button">
+         <property name="minimumSize">
+          <size>
+           <width>75</width>
+           <height>0</height>
+          </size>
+         </property>
          <property name="text">
           <string>Go</string>
          </property>

--- a/lightpath/ui/lightapp.ui
+++ b/lightpath/ui/lightapp.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>1121</width>
-    <height>385</height>
+    <height>408</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -33,7 +33,10 @@
   </property>
   <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,1">
    <item>
-    <layout class="QVBoxLayout" name="option_layout" stretch="0,0,0">
+    <layout class="QVBoxLayout" name="option_layout" stretch="1,1,2,0">
+     <property name="spacing">
+      <number>5</number>
+     </property>
      <property name="topMargin">
       <number>0</number>
      </property>
@@ -43,7 +46,7 @@
      <item>
       <layout class="QHBoxLayout" name="header_layout">
        <item>
-        <layout class="QHBoxLayout" name="button_layout">
+        <layout class="QHBoxLayout" name="button_layout" stretch="0,1">
          <item>
           <widget class="QLabel" name="combo_label">
            <property name="sizePolicy">
@@ -60,96 +63,14 @@
             </font>
            </property>
            <property name="text">
-            <string>Beam Destinations</string>
+            <string>Beam Destination</string>
            </property>
           </widget>
          </item>
          <item>
           <widget class="QComboBox" name="destination_combo"/>
          </item>
-         <item>
-          <layout class="QGridLayout" name="gridLayout">
-           <item row="0" column="0">
-            <widget class="QCheckBox" name="upstream_check">
-             <property name="enabled">
-              <bool>true</bool>
-             </property>
-             <property name="text">
-              <string>Show upstream devices</string>
-             </property>
-             <property name="checked">
-              <bool>true</bool>
-             </property>
-             <property name="tristate">
-              <bool>false</bool>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
         </layout>
-       </item>
-       <item>
-        <spacer name="horizontalSpacer_3">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeType">
-          <enum>QSizePolicy::Expanding</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>5</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
-     </item>
-     <item>
-      <layout class="QHBoxLayout" name="impediment" stretch="1,2,0">
-       <property name="bottomMargin">
-        <number>0</number>
-       </property>
-       <item>
-        <widget class="QLabel" name="impediment_label">
-         <property name="font">
-          <font>
-           <weight>75</weight>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>Current Beam Impediment</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLabel" name="current_impediment">
-         <property name="autoFillBackground">
-          <bool>true</bool>
-         </property>
-         <property name="text">
-          <string>TextLabel</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="impediment_button">
-         <property name="minimumSize">
-          <size>
-           <width>75</width>
-           <height>0</height>
-          </size>
-         </property>
-         <property name="text">
-          <string>Go</string>
-         </property>
-        </widget>
        </item>
       </layout>
      </item>
@@ -165,6 +86,55 @@
         <string>Navigation</string>
        </property>
        <layout class="QVBoxLayout" name="verticalLayout">
+        <property name="spacing">
+         <number>10</number>
+        </property>
+        <item>
+         <layout class="QHBoxLayout" name="impediment" stretch="1,2,0">
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <item>
+           <widget class="QLabel" name="impediment_label">
+            <property name="font">
+             <font>
+              <weight>75</weight>
+              <bold>true</bold>
+             </font>
+            </property>
+            <property name="text">
+             <string>Current Beam Impediment</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="current_impediment">
+            <property name="autoFillBackground">
+             <bool>true</bool>
+            </property>
+            <property name="text">
+             <string>TextLabel</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="impediment_button">
+            <property name="minimumSize">
+             <size>
+              <width>75</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="text">
+             <string>Go</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
         <item>
          <layout class="QHBoxLayout" name="find_device" stretch="0,1">
           <property name="spacing">
@@ -191,6 +161,68 @@
           </item>
          </layout>
         </item>
+       </layout>
+      </widget>
+     </item>
+     <item>
+      <widget class="QGroupBox" name="filter_options">
+       <property name="font">
+        <font>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="title">
+        <string>Filtering Options</string>
+       </property>
+       <layout class="QVBoxLayout" name="verticalLayout_2" stretch="0,0,0">
+        <property name="spacing">
+         <number>3</number>
+        </property>
+        <property name="topMargin">
+         <number>10</number>
+        </property>
+        <property name="bottomMargin">
+         <number>10</number>
+        </property>
+        <item>
+         <widget class="QCheckBox" name="upstream_check">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+          <property name="font">
+           <font>
+            <weight>50</weight>
+            <bold>false</bold>
+           </font>
+          </property>
+          <property name="text">
+           <string>Show upstream devices</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+          <property name="tristate">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="remove_check">
+          <property name="font">
+           <font>
+            <weight>50</weight>
+            <bold>false</bold>
+           </font>
+          </property>
+          <property name="text">
+           <string>Show removed devices</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
         <item>
          <widget class="QGroupBox" name="device_types">
           <property name="font">
@@ -204,21 +236,24 @@
           </property>
          </widget>
         </item>
-        <item>
-         <spacer name="verticalSpacer">
-          <property name="orientation">
-           <enum>Qt::Vertical</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>20</width>
-            <height>40</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
        </layout>
       </widget>
+     </item>
+     <item>
+      <spacer name="verticalSpacer">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::MinimumExpanding</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>5</height>
+        </size>
+       </property>
+      </spacer>
      </item>
     </layout>
    </item>
@@ -270,8 +305,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>708</width>
-        <height>365</height>
+        <width>755</width>
+        <height>388</height>
        </rect>
       </property>
       <property name="sizePolicy">

--- a/lightpath/ui/lightapp.ui
+++ b/lightpath/ui/lightapp.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>700</width>
-    <height>472</height>
+    <width>710</width>
+    <height>385</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -43,22 +43,6 @@
      <item>
       <layout class="QHBoxLayout" name="header_layout">
        <item>
-        <spacer name="horizontalSpacer_2">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeType">
-          <enum>QSizePolicy::Expanding</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>5</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item>
         <layout class="QHBoxLayout" name="button_layout">
          <item>
           <widget class="QLabel" name="combo_label">
@@ -85,7 +69,7 @@
          </item>
          <item>
           <layout class="QGridLayout" name="gridLayout">
-           <item row="0" column="1">
+           <item row="0" column="0">
             <widget class="QCheckBox" name="upstream_check">
              <property name="enabled">
               <bool>true</bool>
@@ -100,81 +84,6 @@
               <bool>false</bool>
              </property>
             </widget>
-           </item>
-           <item row="0" column="0">
-            <widget class="QLabel" name="label">
-             <property name="font">
-              <font>
-               <weight>75</weight>
-               <bold>true</bold>
-              </font>
-             </property>
-             <property name="text">
-              <string>Minimum Transmission</string>
-             </property>
-             <property name="alignment">
-              <set>Qt::AlignCenter</set>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="0">
-            <layout class="QHBoxLayout" name="horizontalLayout">
-             <item>
-              <widget class="QLabel" name="label_2">
-               <property name="font">
-                <font>
-                 <pointsize>10</pointsize>
-                </font>
-               </property>
-               <property name="text">
-                <string>1</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QSlider" name="transmission_slider">
-               <property name="minimum">
-                <number>1</number>
-               </property>
-               <property name="maximum">
-                <number>100</number>
-               </property>
-               <property name="value">
-                <number>80</number>
-               </property>
-               <property name="tracking">
-                <bool>false</bool>
-               </property>
-               <property name="orientation">
-                <enum>Qt::Horizontal</enum>
-               </property>
-               <property name="invertedAppearance">
-                <bool>false</bool>
-               </property>
-               <property name="invertedControls">
-                <bool>false</bool>
-               </property>
-               <property name="tickPosition">
-                <enum>QSlider::TicksAbove</enum>
-               </property>
-               <property name="tickInterval">
-                <number>20</number>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QLabel" name="label_3">
-               <property name="font">
-                <font>
-                 <pointsize>10</pointsize>
-                </font>
-               </property>
-               <property name="text">
-                <string>100</string>
-               </property>
-              </widget>
-             </item>
-            </layout>
            </item>
           </layout>
          </item>
@@ -246,8 +155,8 @@
          <rect>
           <x>0</x>
           <y>0</y>
-          <width>664</width>
-          <height>386</height>
+          <width>674</width>
+          <height>325</height>
          </rect>
         </property>
         <property name="sizePolicy">

--- a/lightpath/ui/lightapp.ui
+++ b/lightpath/ui/lightapp.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>710</width>
+    <width>1121</width>
     <height>385</height>
    </rect>
   </property>
@@ -31,14 +31,14 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
+  <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,1">
    <item>
-    <layout class="QVBoxLayout" name="app_layout">
-     <property name="spacing">
-      <number>10</number>
+    <layout class="QVBoxLayout" name="option_layout" stretch="0,0,0">
+     <property name="topMargin">
+      <number>0</number>
      </property>
-     <property name="sizeConstraint">
-      <enum>QLayout::SetDefaultConstraint</enum>
+     <property name="rightMargin">
+      <number>0</number>
      </property>
      <item>
       <layout class="QHBoxLayout" name="header_layout">
@@ -108,73 +108,180 @@
       </layout>
      </item>
      <item>
-      <widget class="QScrollArea" name="scroll">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
-         <horstretch>10</horstretch>
-         <verstretch>10</verstretch>
-        </sizepolicy>
+      <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="1,2,0">
+       <property name="bottomMargin">
+        <number>0</number>
        </property>
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>0</height>
-        </size>
-       </property>
+       <item>
+        <widget class="QLabel" name="label">
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Current Beam Impediment</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="label_2">
+         <property name="autoFillBackground">
+          <bool>true</bool>
+         </property>
+         <property name="text">
+          <string>TextLabel</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="pushButton">
+         <property name="text">
+          <string>Go</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <widget class="QGroupBox" name="navigation">
        <property name="font">
         <font>
-         <kerning>false</kerning>
+         <weight>75</weight>
+         <bold>true</bold>
         </font>
        </property>
-       <property name="layoutDirection">
-        <enum>Qt::LeftToRight</enum>
+       <property name="title">
+        <string>Navigation</string>
        </property>
-       <property name="autoFillBackground">
-        <bool>false</bool>
-       </property>
-       <property name="frameShape">
-        <enum>QFrame::StyledPanel</enum>
-       </property>
-       <property name="frameShadow">
-        <enum>QFrame::Raised</enum>
-       </property>
-       <property name="verticalScrollBarPolicy">
-        <enum>Qt::ScrollBarAlwaysOn</enum>
-       </property>
-       <property name="horizontalScrollBarPolicy">
-        <enum>Qt::ScrollBarAsNeeded</enum>
-       </property>
-       <property name="sizeAdjustPolicy">
-        <enum>QAbstractScrollArea::AdjustToContents</enum>
-       </property>
-       <property name="widgetResizable">
-        <bool>true</bool>
-       </property>
-       <widget class="QWidget" name="widget_rows">
-        <property name="geometry">
-         <rect>
-          <x>0</x>
-          <y>0</y>
-          <width>674</width>
-          <height>325</height>
-         </rect>
-        </property>
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Minimum">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>0</height>
-         </size>
-        </property>
-       </widget>
+       <layout class="QVBoxLayout" name="verticalLayout">
+        <item>
+         <layout class="QHBoxLayout" name="find_device" stretch="0,1">
+          <property name="spacing">
+           <number>15</number>
+          </property>
+          <property name="bottomMargin">
+           <number>5</number>
+          </property>
+          <item>
+           <widget class="QLabel" name="find_device_label">
+            <property name="font">
+             <font>
+              <weight>75</weight>
+              <bold>true</bold>
+             </font>
+            </property>
+            <property name="text">
+             <string>Find Device</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QComboBox" name="device_combo"/>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <widget class="QGroupBox" name="device_types">
+          <property name="font">
+           <font>
+            <weight>75</weight>
+            <bold>true</bold>
+           </font>
+          </property>
+          <property name="title">
+           <string>Included Device Types</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="verticalSpacer">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
       </widget>
      </item>
     </layout>
+   </item>
+   <item>
+    <widget class="QScrollArea" name="scroll">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+       <horstretch>10</horstretch>
+       <verstretch>10</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="font">
+      <font>
+       <kerning>false</kerning>
+      </font>
+     </property>
+     <property name="layoutDirection">
+      <enum>Qt::LeftToRight</enum>
+     </property>
+     <property name="autoFillBackground">
+      <bool>false</bool>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <property name="verticalScrollBarPolicy">
+      <enum>Qt::ScrollBarAlwaysOn</enum>
+     </property>
+     <property name="horizontalScrollBarPolicy">
+      <enum>Qt::ScrollBarAsNeeded</enum>
+     </property>
+     <property name="sizeAdjustPolicy">
+      <enum>QAbstractScrollArea::AdjustToContents</enum>
+     </property>
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="widget_rows">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>708</width>
+        <height>365</height>
+       </rect>
+      </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="MinimumExpanding" vsizetype="Minimum">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>0</width>
+        <height>0</height>
+       </size>
+      </property>
+     </widget>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/lightpath/ui/widgets.py
+++ b/lightpath/ui/widgets.py
@@ -129,18 +129,18 @@ class LightRow(InactiveRow):
         green or red to quickly
         """
         # Interpret state
-        state = find_device_state(self.device)
+        self.last_state = find_device_state(self.device)
         # Set label to state description
-        self.state_label.setText(state.name)
-        color = state_colors[state.value]
+        self.state_label.setText(self.last_state.name)
+        color = state_colors[self.last_state.value]
         style_color = to_stylesheet_color(color)
         self.state_label.setStyleSheet("QLabel {color: %s}" % style_color)
         self.device_drawing._default_color = color
         self.device_drawing.update()
         # Disable buttons if necessary
-        self.insert_button.setEnabled((state != DeviceState.Inserted
+        self.insert_button.setEnabled((self.last_state != DeviceState.Inserted
                                        and hasattr(self.device, 'insert')))
-        self.remove_button.setEnabled((state != DeviceState.Removed
+        self.remove_button.setEnabled((self.last_state != DeviceState.Removed
                                        and hasattr(self.device, 'remove')))
 
     def clear_sub(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 coloredlogs
-prettytable
-ophyd
-pydm
 happi
+numpy
+ophyd
 pcdsdevices
+prettytable
+pydm
 pyqt


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
A bunch of helpful navigation widget options. You can now:
* Force scroll to an arbitrary device
* Force scroll to the most upstream blocking device
* Hide devices that are removed from the beam
* Hide devices based on their class

I also implemented the `upstream` filter in the more general structure now. This means we **only** disconnect / reconnect to widgets when we switch beamlines. Avoid loading the entire beampath whenever possible!

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #73 
Closes #67 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added tests for all new functions

## Screenshots (if appropriate):
<img width="1233" alt="screen shot 2018-07-19 at 4 26 01 pm" src="https://user-images.githubusercontent.com/25753048/42975335-7881e576-8b70-11e8-93fa-c5bd92a41836.png">
