### PR TITLE
ENH: Beamline Overview

### DIFF
--- a/lightpath/tests/test_gui.py
+++ b/lightpath/tests/test_gui.py
@@ -24,7 +24,7 @@ def test_lightpath_launch_script():
 
 def test_focus_on_device(lcls_client, monkeypatch):
     lightapp = LightApp(LightController(lcls_client))
-    row = lightapp.rows[8]
+    row = lightapp.rows[8][0]
     monkeypatch.setattr(lightapp.scroll,
                         'ensureWidgetVisible',
                         Mock())
@@ -32,7 +32,7 @@ def test_focus_on_device(lcls_client, monkeypatch):
     lightapp.focus_on_device(name=row.device.name)
     lightapp.scroll.ensureWidgetVisible.assert_called_with(row)
     # Go to impediment if no device is provided
-    first_row = lightapp.rows[0]
+    first_row = lightapp.rows[0][0]
     first_row.insert()
     lightapp.focus_on_device()
     lightapp.scroll.ensureWidgetVisible.assert_called_with(first_row)
@@ -48,23 +48,23 @@ def test_filtering(lcls_client, monkeypatch):
     # Hide Crystal devices
     lightapp.show_devicetype(False, Crystal)
     for row in lightapp.rows:
-        if isinstance(row.device, Crystal):
-            row.setVisible.assert_called_with(False)
+        if isinstance(row[0].device, Crystal):
+            row[0].setVisible.assert_called_with(False)
     # Show Crystal devices
     lightapp.show_devicetype(True, Crystal)
     for row in lightapp.rows:
-        if isinstance(row.device, Crystal):
-            row.setVisible.assert_called_with(True)
+        if isinstance(row[0].device, Crystal):
+            row[0].setVisible.assert_called_with(True)
     # Insert at least one device then hide
-    device_row = lightapp.rows[2]
+    device_row = lightapp.rows[2][0]
     device_row.device.insert()
     lightapp.show_removed(False)
     for row in lightapp.rows:
-        if row.device.inserted:
-            row.setVisible.assert_called_with(False)
+        if row[0].device.inserted:
+            row[0].setVisible.assert_called_with(False)
     # Hide upstream devices
     lightapp.select_devices('MEC')
     lightapp.show_upstream(False)
     for row in lightapp.rows:
-        if row.device.md.beamline != 'MEC':
-            row.setVisible.assert_called_with(False)
+        if row[0].device.md.beamline != 'MEC':
+            row[0].setVisible.assert_called_with(False)

--- a/lightpath/ui/device.ui
+++ b/lightpath/ui/device.ui
@@ -327,7 +327,7 @@
     </widget>
    </item>
    <item alignment="Qt::AlignHCenter">
-    <widget class="QWidget" name="widget" native="true">
+    <widget class="QWidget" name="commands" native="true">
      <layout class="QVBoxLayout" name="command_layout">
       <property name="leftMargin">
        <number>5</number>

--- a/lightpath/ui/device.ui
+++ b/lightpath/ui/device.ui
@@ -11,15 +11,15 @@
    </rect>
   </property>
   <property name="sizePolicy">
-   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+   <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>
   </property>
   <property name="minimumSize">
    <size>
-    <width>145</width>
-    <height>250</height>
+    <width>25</width>
+    <height>25</height>
    </size>
   </property>
   <property name="windowTitle">
@@ -150,7 +150,10 @@
        <height>16777215</height>
       </size>
      </property>
-     <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,0,0">
+     <layout class="QHBoxLayout" name="horizontalLayout" stretch="1,0,1">
+      <property name="spacing">
+       <number>5</number>
+      </property>
       <property name="sizeConstraint">
        <enum>QLayout::SetDefaultConstraint</enum>
       </property>
@@ -220,8 +223,8 @@
         </property>
         <property name="minimumSize">
          <size>
-          <width>50</width>
-          <height>50</height>
+          <width>5</width>
+          <height>5</height>
          </size>
         </property>
         <property name="maximumSize">

--- a/lightpath/ui/device.ui
+++ b/lightpath/ui/device.ui
@@ -18,7 +18,7 @@
   </property>
   <property name="minimumSize">
    <size>
-    <width>25</width>
+    <width>20</width>
     <height>25</height>
    </size>
   </property>
@@ -152,15 +152,21 @@
      </property>
      <layout class="QHBoxLayout" name="horizontalLayout" stretch="1,0,1">
       <property name="spacing">
-       <number>5</number>
+       <number>2</number>
       </property>
       <property name="sizeConstraint">
        <enum>QLayout::SetDefaultConstraint</enum>
       </property>
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
       <property name="bottomMargin">
        <number>5</number>
       </property>
-      <item>
+      <item alignment="Qt::AlignVCenter">
        <widget class="PyDMDrawingRectangle" name="beam_indicator">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -170,7 +176,7 @@
         </property>
         <property name="minimumSize">
          <size>
-          <width>0</width>
+          <width>10</width>
           <height>15</height>
          </size>
         </property>
@@ -213,7 +219,7 @@
         </property>
        </widget>
       </item>
-      <item alignment="Qt::AlignHCenter">
+      <item alignment="Qt::AlignHCenter|Qt::AlignVCenter">
        <widget class="PyDMDrawingRectangle" name="device_drawing">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -223,8 +229,8 @@
         </property>
         <property name="minimumSize">
          <size>
-          <width>5</width>
-          <height>5</height>
+          <width>10</width>
+          <height>10</height>
          </size>
         </property>
         <property name="maximumSize">

--- a/lightpath/ui/gui.py
+++ b/lightpath/ui/gui.py
@@ -59,6 +59,13 @@ class LightApp(Display):
         self.device_types.setLayout(QGridLayout())
         self.overview.setLayout(QHBoxLayout())
         self.overview.layout().setSpacing(1)
+        # Setup the fancy overview slider
+        slide_scroll = self.scroll.horizontalScrollBar()
+        self.slide.setRange(slide_scroll.minimum(),
+                            slide_scroll.maximum())
+        self.slide.sliderMoved.connect(slide_scroll.setSliderPosition)
+        slide_scroll.rangeChanged.connect(self.slide.setRange)
+        slide_scroll.valueChanged.connect(self.slide.setSliderPosition)
         # Add destinations
         for line in self.destinations():
             self.destination_combo.addItem(line)
@@ -95,7 +102,7 @@ class LightApp(Display):
                                             device=device_type))
         # Setup the UI
         self.change_path_display()
-
+        self.resizeSlider()
         # Change the stylesheet
         if dark:
             try:
@@ -286,3 +293,24 @@ class LightApp(Display):
         Clear the subscription event
         """
         self.path.clear_sub(self.update_path)
+
+    def resizeSlider(self):
+        # Visible area of beamline
+        visible = self.scroll.width() / self.scroll.widget().width()
+        # Take same fraction of bar up in handle width
+        slider_size = round(self.slide.width() * visible)
+        # Set Stylesheet
+        self.slide.setStyleSheet('QSlider::handle'
+                                 '{width: %spx;'
+                                 'background: rgb(124, 252, 0);}'
+                                 '' % slider_size)
+
+    def show(self):
+        # Comandeered to assure that slider is initialized properly
+        super().show()
+        self.resizeSlider()
+
+    def resizeEvent(self, evt):
+        # Further resize-ing of the widget should affect the fancy slider
+        super().resizeEvent(evt)
+        self.resizeSlider()

--- a/lightpath/ui/gui.py
+++ b/lightpath/ui/gui.py
@@ -58,7 +58,8 @@ class LightApp(Display):
         self.widget_rows.setLayout(self.lightLayout)
         self.device_types.setLayout(QGridLayout())
         self.overview.setLayout(QHBoxLayout())
-        self.overview.layout().setSpacing(1)
+        self.overview.layout().setSpacing(2)
+        self.overview.layout().setContentsMargins(2, 2, 2, 2)
         # Setup the fancy overview slider
         slide_scroll = self.scroll.horizontalScrollBar()
         self.slide.setRange(slide_scroll.minimum(),

--- a/lightpath/ui/gui.py
+++ b/lightpath/ui/gui.py
@@ -284,9 +284,12 @@ class LightApp(Display):
 
     def _filter(self, show, func):
         """Helper function to hide a device based on a condition"""
+        # Hide widgets
         for row in self.rows:
             if func(row[0]):
                 row[0].setVisible(show)
+        # Resize slider
+        self.resizeSlider()
 
     def clear_subs(self):
         """

--- a/lightpath/ui/lightapp.ui
+++ b/lightpath/ui/lightapp.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1121</width>
-    <height>408</height>
+    <width>1199</width>
+    <height>493</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -31,200 +31,64 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,1">
+  <layout class="QVBoxLayout" name="verticalLayout_3" stretch="0,1">
    <item>
-    <layout class="QVBoxLayout" name="option_layout" stretch="1,1,2,0">
-     <property name="spacing">
-      <number>5</number>
+    <widget class="QFrame" name="overview">
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
      </property>
-     <property name="topMargin">
-      <number>0</number>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
      </property>
-     <property name="rightMargin">
-      <number>0</number>
-     </property>
-     <item>
-      <layout class="QHBoxLayout" name="header_layout">
-       <item>
-        <layout class="QHBoxLayout" name="button_layout" stretch="0,1">
-         <item>
-          <widget class="QLabel" name="combo_label">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="font">
-            <font>
-             <pointsize>10</pointsize>
-             <weight>75</weight>
-             <bold>true</bold>
-            </font>
-           </property>
-           <property name="text">
-            <string>Beam Destination</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QComboBox" name="destination_combo"/>
-         </item>
-        </layout>
-       </item>
-      </layout>
-     </item>
-     <item>
-      <widget class="QGroupBox" name="navigation">
-       <property name="font">
-        <font>
-         <weight>75</weight>
-         <bold>true</bold>
-        </font>
-       </property>
-       <property name="title">
-        <string>Navigation</string>
-       </property>
-       <layout class="QVBoxLayout" name="verticalLayout">
+    </widget>
+   </item>
+   <item>
+    <widget class="QWidget" name="detailed" native="true">
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <item>
+       <layout class="QVBoxLayout" name="option_layout" stretch="1,1,2,0">
         <property name="spacing">
-         <number>10</number>
-        </property>
-        <item>
-         <layout class="QHBoxLayout" name="impediment" stretch="1,2,0">
-          <property name="bottomMargin">
-           <number>0</number>
-          </property>
-          <item>
-           <widget class="QLabel" name="impediment_label">
-            <property name="font">
-             <font>
-              <weight>75</weight>
-              <bold>true</bold>
-             </font>
-            </property>
-            <property name="text">
-             <string>Current Beam Impediment</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QLabel" name="current_impediment">
-            <property name="autoFillBackground">
-             <bool>true</bool>
-            </property>
-            <property name="text">
-             <string>TextLabel</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="impediment_button">
-            <property name="minimumSize">
-             <size>
-              <width>75</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="text">
-             <string>Go</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item>
-         <layout class="QHBoxLayout" name="find_device" stretch="0,1">
-          <property name="spacing">
-           <number>15</number>
-          </property>
-          <property name="bottomMargin">
-           <number>5</number>
-          </property>
-          <item>
-           <widget class="QLabel" name="find_device_label">
-            <property name="font">
-             <font>
-              <weight>75</weight>
-              <bold>true</bold>
-             </font>
-            </property>
-            <property name="text">
-             <string>Find Device</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QComboBox" name="device_combo"/>
-          </item>
-         </layout>
-        </item>
-       </layout>
-      </widget>
-     </item>
-     <item>
-      <widget class="QGroupBox" name="filter_options">
-       <property name="font">
-        <font>
-         <weight>75</weight>
-         <bold>true</bold>
-        </font>
-       </property>
-       <property name="title">
-        <string>Filtering Options</string>
-       </property>
-       <layout class="QVBoxLayout" name="verticalLayout_2" stretch="0,0,0">
-        <property name="spacing">
-         <number>3</number>
+         <number>5</number>
         </property>
         <property name="topMargin">
-         <number>10</number>
+         <number>0</number>
         </property>
-        <property name="bottomMargin">
-         <number>10</number>
+        <property name="rightMargin">
+         <number>0</number>
         </property>
         <item>
-         <widget class="QCheckBox" name="upstream_check">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
-          <property name="font">
-           <font>
-            <weight>50</weight>
-            <bold>false</bold>
-           </font>
-          </property>
-          <property name="text">
-           <string>Show upstream devices</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-          <property name="tristate">
-           <bool>false</bool>
-          </property>
-         </widget>
+         <layout class="QHBoxLayout" name="header_layout">
+          <item>
+           <layout class="QHBoxLayout" name="button_layout" stretch="0,1">
+            <item>
+             <widget class="QLabel" name="combo_label">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="font">
+               <font>
+                <pointsize>10</pointsize>
+                <weight>75</weight>
+                <bold>true</bold>
+               </font>
+              </property>
+              <property name="text">
+               <string>Beam Destination</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QComboBox" name="destination_combo"/>
+            </item>
+           </layout>
+          </item>
+         </layout>
         </item>
         <item>
-         <widget class="QCheckBox" name="remove_check">
-          <property name="font">
-           <font>
-            <weight>50</weight>
-            <bold>false</bold>
-           </font>
-          </property>
-          <property name="text">
-           <string>Show removed devices</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QGroupBox" name="device_types">
+         <widget class="QGroupBox" name="navigation">
           <property name="font">
            <font>
             <weight>75</weight>
@@ -232,96 +96,248 @@
            </font>
           </property>
           <property name="title">
-           <string>Included Device Types</string>
+           <string>Navigation</string>
           </property>
+          <layout class="QVBoxLayout" name="verticalLayout">
+           <property name="spacing">
+            <number>10</number>
+           </property>
+           <item>
+            <layout class="QHBoxLayout" name="impediment" stretch="1,2,0">
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <item>
+              <widget class="QLabel" name="impediment_label">
+               <property name="font">
+                <font>
+                 <weight>75</weight>
+                 <bold>true</bold>
+                </font>
+               </property>
+               <property name="text">
+                <string>Current Beam Impediment</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLabel" name="current_impediment">
+               <property name="autoFillBackground">
+                <bool>true</bool>
+               </property>
+               <property name="text">
+                <string>TextLabel</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignCenter</set>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QPushButton" name="impediment_button">
+               <property name="minimumSize">
+                <size>
+                 <width>75</width>
+                 <height>0</height>
+                </size>
+               </property>
+               <property name="text">
+                <string>Go</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+           <item>
+            <layout class="QHBoxLayout" name="find_device" stretch="0,1">
+             <property name="spacing">
+              <number>15</number>
+             </property>
+             <property name="bottomMargin">
+              <number>5</number>
+             </property>
+             <item>
+              <widget class="QLabel" name="find_device_label">
+               <property name="font">
+                <font>
+                 <weight>75</weight>
+                 <bold>true</bold>
+                </font>
+               </property>
+               <property name="text">
+                <string>Find Device</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QComboBox" name="device_combo"/>
+             </item>
+            </layout>
+           </item>
+          </layout>
          </widget>
         </item>
+        <item>
+         <widget class="QGroupBox" name="filter_options">
+          <property name="font">
+           <font>
+            <weight>75</weight>
+            <bold>true</bold>
+           </font>
+          </property>
+          <property name="title">
+           <string>Filtering Options</string>
+          </property>
+          <layout class="QVBoxLayout" name="verticalLayout_2" stretch="0,0,0">
+           <property name="spacing">
+            <number>3</number>
+           </property>
+           <property name="topMargin">
+            <number>10</number>
+           </property>
+           <property name="bottomMargin">
+            <number>10</number>
+           </property>
+           <item>
+            <widget class="QCheckBox" name="upstream_check">
+             <property name="enabled">
+              <bool>true</bool>
+             </property>
+             <property name="font">
+              <font>
+               <weight>50</weight>
+               <bold>false</bold>
+              </font>
+             </property>
+             <property name="text">
+              <string>Show upstream devices</string>
+             </property>
+             <property name="checked">
+              <bool>true</bool>
+             </property>
+             <property name="tristate">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QCheckBox" name="remove_check">
+             <property name="font">
+              <font>
+               <weight>50</weight>
+               <bold>false</bold>
+              </font>
+             </property>
+             <property name="text">
+              <string>Show removed devices</string>
+             </property>
+             <property name="checked">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QGroupBox" name="device_types">
+             <property name="font">
+              <font>
+               <weight>75</weight>
+               <bold>true</bold>
+              </font>
+             </property>
+             <property name="title">
+              <string>Included Device Types</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <spacer name="verticalSpacer">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeType">
+           <enum>QSizePolicy::MinimumExpanding</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>5</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
        </layout>
-      </widget>
-     </item>
-     <item>
-      <spacer name="verticalSpacer">
-       <property name="orientation">
-        <enum>Qt::Vertical</enum>
-       </property>
-       <property name="sizeType">
-        <enum>QSizePolicy::MinimumExpanding</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>20</width>
-         <height>5</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <widget class="QScrollArea" name="scroll">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
-       <horstretch>10</horstretch>
-       <verstretch>10</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>0</height>
-      </size>
-     </property>
-     <property name="font">
-      <font>
-       <kerning>false</kerning>
-      </font>
-     </property>
-     <property name="layoutDirection">
-      <enum>Qt::LeftToRight</enum>
-     </property>
-     <property name="autoFillBackground">
-      <bool>false</bool>
-     </property>
-     <property name="frameShape">
-      <enum>QFrame::StyledPanel</enum>
-     </property>
-     <property name="frameShadow">
-      <enum>QFrame::Raised</enum>
-     </property>
-     <property name="verticalScrollBarPolicy">
-      <enum>Qt::ScrollBarAlwaysOn</enum>
-     </property>
-     <property name="horizontalScrollBarPolicy">
-      <enum>Qt::ScrollBarAsNeeded</enum>
-     </property>
-     <property name="sizeAdjustPolicy">
-      <enum>QAbstractScrollArea::AdjustToContents</enum>
-     </property>
-     <property name="widgetResizable">
-      <bool>true</bool>
-     </property>
-     <widget class="QWidget" name="widget_rows">
-      <property name="geometry">
-       <rect>
-        <x>0</x>
-        <y>0</y>
-        <width>755</width>
-        <height>388</height>
-       </rect>
-      </property>
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="MinimumExpanding" vsizetype="Minimum">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
-      <property name="minimumSize">
-       <size>
-        <width>0</width>
-        <height>0</height>
-       </size>
-      </property>
-     </widget>
+      </item>
+      <item>
+       <widget class="QScrollArea" name="scroll">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+          <horstretch>10</horstretch>
+          <verstretch>10</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="font">
+         <font>
+          <kerning>false</kerning>
+         </font>
+        </property>
+        <property name="layoutDirection">
+         <enum>Qt::LeftToRight</enum>
+        </property>
+        <property name="autoFillBackground">
+         <bool>false</bool>
+        </property>
+        <property name="frameShape">
+         <enum>QFrame::StyledPanel</enum>
+        </property>
+        <property name="frameShadow">
+         <enum>QFrame::Raised</enum>
+        </property>
+        <property name="verticalScrollBarPolicy">
+         <enum>Qt::ScrollBarAlwaysOn</enum>
+        </property>
+        <property name="horizontalScrollBarPolicy">
+         <enum>Qt::ScrollBarAsNeeded</enum>
+        </property>
+        <property name="sizeAdjustPolicy">
+         <enum>QAbstractScrollArea::AdjustToContents</enum>
+        </property>
+        <property name="widgetResizable">
+         <bool>true</bool>
+        </property>
+        <widget class="QWidget" name="widget_rows">
+         <property name="geometry">
+          <rect>
+           <x>0</x>
+           <y>0</y>
+           <width>815</width>
+           <height>439</height>
+          </rect>
+         </property>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Minimum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>0</height>
+          </size>
+         </property>
+        </widget>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
   </layout>

--- a/lightpath/ui/lightapp.ui
+++ b/lightpath/ui/lightapp.ui
@@ -31,7 +31,29 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_3" stretch="0,1">
+  <layout class="QVBoxLayout" name="verticalLayout_3" stretch="0,0,1">
+   <item>
+    <widget class="QSlider" name="slide">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>5</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>5</height>
+      </size>
+     </property>
+     <property name="styleSheet">
+      <string notr="true"/>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
    <item>
     <widget class="QFrame" name="overview">
      <property name="frameShape">
@@ -319,7 +341,7 @@
            <x>0</x>
            <y>0</y>
            <width>815</width>
-           <height>439</height>
+           <height>428</height>
           </rect>
          </property>
          <property name="sizePolicy">

--- a/lightpath/ui/widgets.py
+++ b/lightpath/ui/widgets.py
@@ -69,9 +69,9 @@ class InactiveRow(Display):
         self.commands.hide()
         # Resize drawings
         self.out_indicator.hide()
-        self.device_drawing.setFixedSize(15, 15)
-        self.horizontalWidget.layout().setSpacing(2)
-
+        self.device_drawing.setFixedHeight(15)
+        self.device_drawing.setMaximumWidth(15)
+        self.horizontalWidget.layout().setSpacing(1)
 
 
 class LightRow(InactiveRow):

--- a/lightpath/ui/widgets.py
+++ b/lightpath/ui/widgets.py
@@ -72,15 +72,6 @@ class InactiveRow(Display):
         self.device_drawing.setFixedSize(15, 15)
         self.horizontalWidget.layout().setSpacing(2)
 
-    def expand(self):
-        """Re-expand the size of the widget to show the device"""
-        # Show commands and labels
-        self.device_information.show()
-        self.commands.show()
-        # Resize drawings
-        self.out_indicator.show()
-        self.device_drawing.setFixedSize(50, 50)
-        self.horizontalWidget.layout().setSpacing(5)
 
 
 class LightRow(InactiveRow):

--- a/lightpath/ui/widgets.py
+++ b/lightpath/ui/widgets.py
@@ -62,6 +62,26 @@ class InactiveRow(Display):
         """
         pass
 
+    def condense(self):
+        """Reduce the size of the widget when the device is hidden"""
+        # Hide commands and labels
+        self.device_information.hide()
+        self.commands.hide()
+        # Resize drawings
+        self.out_indicator.hide()
+        self.device_drawing.setFixedSize(15, 15)
+        self.horizontalWidget.layout().setSpacing(2)
+
+    def expand(self):
+        """Re-expand the size of the widget to show the device"""
+        # Show commands and labels
+        self.device_information.show()
+        self.commands.show()
+        # Resize drawings
+        self.out_indicator.show()
+        self.device_drawing.setFixedSize(50, 50)
+        self.horizontalWidget.layout().setSpacing(5)
+
 
 class LightRow(InactiveRow):
     """

--- a/lightpath/ui/widgets.py
+++ b/lightpath/ui/widgets.py
@@ -5,7 +5,7 @@ import logging
 import os.path
 
 from pydm import Display
-from pydm.PyQt.QtCore import pyqtSlot
+from pydm.PyQt.QtCore import pyqtSlot, Qt
 from pydm.PyQt.QtGui import QColor
 
 from lightpath.path import find_device_state, DeviceState
@@ -162,6 +162,18 @@ class LightRow(InactiveRow):
                                        and hasattr(self.device, 'insert')))
         self.remove_button.setEnabled((self.last_state != DeviceState.Removed
                                        and hasattr(self.device, 'remove')))
+
+    def update_light(self, _in, _out):
+        """Update the light beams striking and emitting from the device"""
+        for (widget, state) in zip((self.beam_indicator, self.out_indicator),
+                                   (_in, _out)):
+            # Set color
+            if state:
+                widget._default_color = Qt.cyan
+            else:
+                widget._default_color = Qt.gray
+            # Update
+            widget.update()
 
     def clear_sub(self):
         """


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
There is now a widget at the top of the screen that shows a condensed view of the entire beamline. This is to help orient operators where they are in space when looking at the detailed view. To make this even more intuitive I created another slider that shows which swathe of the overview you have open in the detailed view. This can be also dragged around to inspect different portions.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #64 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Modified existing tests to pass, but no new tests were added. 

## Screenshots (if appropriate):
![lightpath](https://user-images.githubusercontent.com/25753048/44820080-37907380-aba4-11e8-941d-83e675bd4d89.gif)
