### PR TITLE
ENH: Typhon

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
   - conda config --append channels conda-forge
   # Useful for debugging any issues with conda
   - conda info -a
-  - conda build -q conda-recipe --output-folder bld-dir
+  - conda build -q conda-recipe --python=$TRAVIS_PYTHON_VERSION --output-folder bld-dir
   - conda config --add channels "file://`pwd`/bld-dir"
   # Create test environment
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION lightpath --file dev-requirements.txt

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
       - pcdsdevices
       - pydm
       - pyqt >=5 
-
+      - typhon
 test:
     imports:
       - lightpath

--- a/examples/demo.py
+++ b/examples/demo.py
@@ -25,7 +25,7 @@ def main():
     #Gather devices
     cntrl = LightController(lightpath.tests.lcls_client())
     #Create Application
-    app   = pydm.PyQt.QtGui.QApplication([])
+    app = pydm.PyDMApplication()
     #Create Lightpath
     light = LightApp(cntrl)
     light.show()

--- a/lightpath/tests/test_gui.py
+++ b/lightpath/tests/test_gui.py
@@ -74,9 +74,12 @@ def test_typhon_display(lcls_client):
     lightapp = LightApp(LightController(lcls_client))
     # Smoke test the hide button without a detailed display
     lightapp.hide_detailed()
-    assert lightapp.horizontalLayout.count() == 2
+    assert lightapp.detail_layout.count() == 2
+    assert lightapp.device_detail.isHidden()
     lightapp.show_detailed(lightapp.rows[0][0].device)
-    assert lightapp.horizontalLayout.count() == 3
+    assert lightapp.detail_layout.count() == 3
+    assert not lightapp.device_detail.isHidden()
     # Smoke test the hide button without a detailed display
     lightapp.hide_detailed()
-    assert lightapp.horizontalLayout.count() == 2
+    assert lightapp.detail_layout.count() == 2
+    assert lightapp.device_detail.isHidden()

--- a/lightpath/tests/test_gui.py
+++ b/lightpath/tests/test_gui.py
@@ -68,3 +68,15 @@ def test_filtering(lcls_client, monkeypatch):
     for row in lightapp.rows:
         if row[0].device.md.beamline != 'MEC':
             row[0].setVisible.assert_called_with(False)
+
+
+def test_typhon_display(lcls_client):
+    lightapp = LightApp(LightController(lcls_client))
+    # Smoke test the hide button without a detailed display
+    lightapp.hide_detailed()
+    assert lightapp.horizontalLayout.count() == 2
+    lightapp.show_detailed(lightapp.rows[0][0].device)
+    assert lightapp.horizontalLayout.count() == 3
+    # Smoke test the hide button without a detailed display
+    lightapp.hide_detailed()
+    assert lightapp.horizontalLayout.count() == 2

--- a/lightpath/ui/default.ui
+++ b/lightpath/ui/default.ui
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>241</width>
+    <height>228</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="PyDMDrawingRectangle" name="PyDMDrawingRectangle">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="whatsThis">
+      <string>
+    A widget with a rectangle drawn in it.
+    This class inherits from PyDMDrawing.
+
+    Parameters
+    ----------
+    parent : QWidget
+        The parent widget for the Label
+    init_channel : str, optional
+        The channel to be used by the widget.
+    </string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>PyDMDrawingRectangle</class>
+   <extends>QWidget</extends>
+   <header>pydm.widgets.drawing</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/lightpath/ui/device.ui
+++ b/lightpath/ui/device.ui
@@ -150,7 +150,7 @@
        <height>16777215</height>
       </size>
      </property>
-     <layout class="QHBoxLayout" name="horizontalLayout" stretch="1,0,1">
+     <layout class="QHBoxLayout" name="horizontalLayout" stretch="1,1">
       <property name="spacing">
        <number>2</number>
       </property>
@@ -213,66 +213,6 @@
         </property>
         <property name="penStyle" stdset="0">
          <enum>Qt::SolidLine</enum>
-        </property>
-        <property name="penWidth" stdset="0">
-         <double>2.000000000000000</double>
-        </property>
-       </widget>
-      </item>
-      <item alignment="Qt::AlignHCenter|Qt::AlignVCenter">
-       <widget class="PyDMDrawingRectangle" name="device_drawing">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>10</width>
-          <height>10</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>50</width>
-          <height>50</height>
-         </size>
-        </property>
-        <property name="toolTip">
-         <string/>
-        </property>
-        <property name="whatsThis">
-         <string>
-    A widget with a rectangle drawn in it.
-    This class inherits from PyDMDrawing.
-
-    Parameters
-    ----------
-    parent : QWidget
-        The parent widget for the Label
-    init_channel : str, optional
-        The channel to be used by the widget.
-    </string>
-        </property>
-        <property name="brush" stdset="0">
-         <brush brushstyle="SolidPattern">
-          <color alpha="255">
-           <red>185</red>
-           <green>185</green>
-           <blue>185</blue>
-          </color>
-         </brush>
-        </property>
-        <property name="penStyle" stdset="0">
-         <enum>Qt::SolidLine</enum>
-        </property>
-        <property name="penColor" stdset="0">
-         <color>
-          <red>0</red>
-          <green>0</green>
-          <blue>0</blue>
-         </color>
         </property>
         <property name="penWidth" stdset="0">
          <double>2.000000000000000</double>

--- a/lightpath/ui/gui.py
+++ b/lightpath/ui/gui.py
@@ -9,7 +9,7 @@ import os.path
 import numpy as np
 import pcdsdevices.device_types as dtypes
 from pcdsdevices.valve import PPSStopper
-from pydm import Display
+from pydm import Display, PyDMApplication
 from pydm.PyQt.QtCore import pyqtSlot
 from pydm.PyQt.QtGui import QHBoxLayout, QGridLayout, QCheckBox
 import typhon
@@ -52,6 +52,7 @@ class LightApp(Display):
         # Store Lightpath information
         self.light = controller
         self.path = None
+        self.detail_screen = None
         self._lock = threading.Lock()
         # Create empty layout
         self.lightLayout = QHBoxLayout()
@@ -296,6 +297,30 @@ class LightApp(Display):
         Clear the subscription event
         """
         self.path.clear_sub(self.update_path)
+
+    @pyqtSlot()
+    def show_detailed(self, device):
+        """Show the Typhon display for a device"""
+        # Hide the last widget
+        self.hide_detailed()
+        # Create a Typhon display
+        self.detail_screen = typhon.DeviceDisplay(device)
+        # Establish connections
+        app = PyDMApplication.instance()
+        app.establish_widget_connections(self.detail_screen)
+        # Add to widget
+        self.horizontalLayout.addWidget(self.detail_screen)
+
+    @pyqtSlot()
+    def hide_detailed(self):
+        """Hide Typhon display for a device"""
+        # Catch the issue when there is no detail_screen already
+        if self.detail_screen:
+            # Remove from layout
+            self.horizontalLayout.removeWidget(self.detail_screen)
+            # Destroy widget
+            self.detail_screen.deleteLater()
+            self.detail_screen = None
 
     def resizeSlider(self):
         # Visible area of beamline

--- a/lightpath/ui/gui.py
+++ b/lightpath/ui/gui.py
@@ -12,6 +12,7 @@ from pcdsdevices.valve import PPSStopper
 from pydm import Display
 from pydm.PyQt.QtCore import pyqtSlot
 from pydm.PyQt.QtGui import QHBoxLayout, QGridLayout, QCheckBox
+import typhon
 
 from lightpath.path import DeviceState
 from .widgets import LightRow
@@ -106,13 +107,7 @@ class LightApp(Display):
         self.resizeSlider()
         # Change the stylesheet
         if dark:
-            try:
-                import qdarkstyle
-            except ImportError:
-                logger.error("Can not use dark theme, "
-                             "qdarkstyle package not available")
-            else:
-                self.setStyleSheet(qdarkstyle.load_stylesheet_pyqt5())
+            typhon.use_stylesheet(dark=True)
 
     def destinations(self):
         """

--- a/lightpath/ui/gui.py
+++ b/lightpath/ui/gui.py
@@ -194,6 +194,10 @@ class LightApp(Display):
                 # Add widget to layout
                 self.lightLayout.addWidget(row[0])
                 self.overview.layout().addWidget(row[1])
+                # Connect condensed widget to focus_on_device
+                row[1].device_drawing.clicked.connect(
+                        partial(self.focus_on_device,
+                                name=row[1].device.name))
                 # Add device to combo
                 self.device_combo.addItem(row[0].device.name)
         # Initialize interface

--- a/lightpath/ui/gui.py
+++ b/lightpath/ui/gui.py
@@ -181,7 +181,8 @@ class LightApp(Display):
                 # Clear subscribed row cache
                 self.rows.clear()
                 self.device_combo.clear()
-
+                # Remove old detailed screen
+                self.hide_detailed()
             # Hide nothing when switching beamlines
             boxes = self.device_types.children()
             boxes.extend([self.upstream_check, self.remove_check])
@@ -199,6 +200,9 @@ class LightApp(Display):
                 row[1].device_drawing.clicked.connect(
                         partial(self.focus_on_device,
                                 name=row[1].device.name))
+                # Connect large widget to show Typhon screen
+                row[0].device_drawing.clicked.connect(
+                        partial(self.show_detailed, row[0].device))
                 # Add device to combo
                 self.device_combo.addItem(row[0].device.name)
         # Initialize interface

--- a/lightpath/ui/lightapp.ui
+++ b/lightpath/ui/lightapp.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="sizePolicy">
-   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+   <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>
@@ -24,7 +24,7 @@
   </property>
   <property name="maximumSize">
    <size>
-    <width>10000</width>
+    <width>16777215</width>
     <height>16777215</height>
    </size>
   </property>
@@ -68,7 +68,7 @@
     <widget class="QWidget" name="detailed" native="true">
      <layout class="QHBoxLayout" name="horizontalLayout">
       <item>
-       <layout class="QVBoxLayout" name="option_layout" stretch="1,1,2,0">
+       <layout class="QVBoxLayout" name="option_layout" stretch="1,1,3,2">
         <property name="spacing">
          <number>5</number>
         </property>
@@ -302,7 +302,7 @@
         </property>
         <property name="minimumSize">
          <size>
-          <width>0</width>
+          <width>400</width>
           <height>0</height>
          </size>
         </property>
@@ -340,8 +340,8 @@
           <rect>
            <x>0</x>
            <y>0</y>
-           <width>815</width>
-           <height>428</height>
+           <width>423</width>
+           <height>434</height>
           </rect>
          </property>
          <property name="sizePolicy">
@@ -357,6 +357,51 @@
           </size>
          </property>
         </widget>
+       </widget>
+      </item>
+      <item>
+       <widget class="QWidget" name="device_detail" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>400</width>
+          <height>0</height>
+         </size>
+        </property>
+        <layout class="QVBoxLayout" name="detail_layout">
+         <item>
+          <layout class="QHBoxLayout" name="detail_buttons">
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QPushButton" name="detail_hide">
+             <property name="text">
+              <string>Hide</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <spacer name="verticalSpacer_2">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>40</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
        </widget>
       </item>
      </layout>

--- a/lightpath/ui/widgets.py
+++ b/lightpath/ui/widgets.py
@@ -5,7 +5,7 @@ import logging
 import os.path
 
 from pydm import Display
-from pydm.PyQt.QtCore import pyqtSlot, Qt
+from pydm.PyQt.QtCore import pyqtSlot, pyqtSignal, Qt
 from pydm.PyQt.QtGui import QColor
 
 from lightpath.path import find_device_state, DeviceState
@@ -171,3 +171,54 @@ class LightRow(InactiveRow):
         Clear the subscription event
         """
         self.device.clear_sub(self.update_state)
+
+
+class DeviceWidget(Display):
+    """
+    Colored Symbol for Lightpath Display
+
+    Parameters
+    ----------
+    symbol_file : str
+        Path to file that contains the Lightpath Symbol
+    """
+    clicked = pyqtSignal()
+
+    def __init__(self, symbol_file, parent=None):
+        self.symbol_file = symbol_file
+        super().__init__(parent=parent)
+        # Default UI settings for conformity
+        self.setMinimumSize(10, 10)
+        self.setMaximumSize(50, 50)
+
+    def ui_filename(self):
+        """
+        Name of designer UI file
+        """
+        return self.symbol_file
+
+    def ui_filepath(self):
+        """
+        Full path to :attr:`.ui_filename`
+        """
+        return os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                            self.ui_filename())
+
+    def setColor(self, color):
+        """
+        Set the color of all PyDMDrawings contained in the widget
+        """
+        style_color = to_stylesheet_color(color)
+        styleSheet = 'PyDMDrawing {qproperty-brush: %s;\
+                                   qproperty-penWidth: 2;\
+                                   qproperty-penStyle: SolidLine;\
+                                   qproperty-penColor: rgb(0, 0, 0);\
+                                   }' % style_color
+        self.setStyleSheet(styleSheet)
+
+    def mousePressEvent(self, evt):
+        """Catch mousePressEvent to emit "`clicked`" pyqtSignal"""
+        # Push MouseEvent through
+        super().mousePressEvent(evt)
+        # Emit click
+        self.clicked.emit()

--- a/lightpath/ui/widgets.py
+++ b/lightpath/ui/widgets.py
@@ -5,8 +5,8 @@ import logging
 import os.path
 
 from pydm import Display
-from pydm.PyQt.QtCore import pyqtSlot, pyqtSignal, Qt
-from pydm.PyQt.QtGui import QColor
+from pydm.PyQt.QtCore import pyqtSlot, pyqtSignal
+from pydm.PyQt.QtGui import QColor, QBrush
 
 from lightpath.path import find_device_state, DeviceState
 
@@ -161,11 +161,9 @@ class LightRow(InactiveRow):
                                    (_in, _out)):
             # Set color
             if state:
-                widget._default_color = Qt.cyan
+                widget.brush = QBrush(QColor('#00ffff'))
             else:
-                widget._default_color = Qt.gray
-            # Update
-            widget.update()
+                widget.brush = QBrush(QColor('#a0a0a4'))
 
     def clear_sub(self):
         """

--- a/lightpath/ui/widgets.py
+++ b/lightpath/ui/widgets.py
@@ -42,6 +42,8 @@ class InactiveRow(Display):
         # By default we mark the device as Disconnected
         self.state_label.setText('Disconnected')
         self.state_label.setStyleSheet("QLabel {color : rgb(255,0,255)}")
+        self.device_drawing = DeviceWidget('default.ui')
+        self.horizontalWidget.layout().insertWidget(1, self.device_drawing)
 
     def ui_filename(self):
         """
@@ -146,8 +148,7 @@ class LightRow(InactiveRow):
         color = state_colors[self.last_state.value]
         style_color = to_stylesheet_color(color)
         self.state_label.setStyleSheet("QLabel {color: %s}" % style_color)
-        self.device_drawing._default_color = color
-        self.device_drawing.update()
+        self.device_drawing.setColor(color)
         # Disable buttons if necessary
         self.insert_button.setEnabled((self.last_state != DeviceState.Inserted
                                        and hasattr(self.device, 'insert')))

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pcdsdevices
 prettytable
 pydm
 pyqt
+typhon


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
### Major Changes
* The base widget to display a Device just added a generic rectangle and changed its color to reflect the state. In the future, we want to support arbitrary symbols containing multiple different `PyDMDrawing`. This PR creates a new widget that loads `.ui` file then whenever the state changes we adjust the stylesheet of **all** `PyDMDrawing` widgets contained inside it. It also sets up some nice shortcuts like every widget 
* When you click on a `DeviceDrawing` in the overview we show the corresponding `typhon.DeviceDisplay` in the sidebar

### Minor Changes
* `Miniconda-latest` is now `3.7`. We need to `conda-build` with the `--python` keyword.
* If you `click` a widget in the overview, we focus on it in the beamline drawing.
* `typhon` is a dependency
* Use the `typhon` machinery to load the dark stylesheet.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #31 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added a test for `show_detailed` and `hide_detailed` functionality

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Docstrings for new functions


## Screenshots (if appropriate):
![lightpath_typhon](https://user-images.githubusercontent.com/25753048/45109569-ccd7be80-b0f4-11e8-9e61-19d2c1c8bd2f.gif)

