### PR TITLE
FIX: Multiple Hidden Conditions

### DIFF
--- a/lightpath/tests/test_gui.py
+++ b/lightpath/tests/test_gui.py
@@ -1,9 +1,7 @@
 from unittest.mock import Mock
 from distutils.spawn import find_executable
 
-from lightpath.ui import LightApp, LightRow
 from lightpath.controller import LightController
-from lightpath.tests.conftest import Crystal
 
 
 def test_app_buttons(lcls_client):

--- a/lightpath/tests/test_gui.py
+++ b/lightpath/tests/test_gui.py
@@ -1,6 +1,7 @@
 from unittest.mock import Mock
 from distutils.spawn import find_executable
 
+from lightpath.ui import LightApp
 from lightpath.controller import LightController
 
 

--- a/lightpath/ui/widgets.py
+++ b/lightpath/ui/widgets.py
@@ -51,6 +51,8 @@ class InactiveRow(Display):
     def __init__(self, device, parent=None):
         super().__init__(parent=parent)
         self.device = device
+        # Initialize prior state variable
+        self.last_state = DeviceState.Disconnected
         # Create labels
         self.name_label.setText(device.name)
         self.prefix_label.setText('({})'.format(device.prefix))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
There was a bug where multiple hidden conditions would override each other. This behavior was rather unintuitive. For a widget to be visible it should have to meet all the selected criteria not just one. This PR consolidates the hidden logic into a single `filter` function which is then triggered by all the buttons.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #81 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Modified test suite for new filtering functions
* Added a check for multiple filtering functions being active simultaneously
