### PR TITLE
FIX: Modify branching logic to ignore removed optics when suitable

### DIFF
--- a/lightpath/path.py
+++ b/lightpath/path.py
@@ -208,7 +208,14 @@ class BeamPath(OphydObject):
             if prior and device.md.beamline != prior.md.beamline:
                 # Find improperly configured optics
                 for optic in last_branches:
-                    if device.md.beamline not in optic.destination:
+                    # If this optic is responsible for delivering beam
+                    # to this hutch and it is not configured to do so.
+                    # Mark it as blocking
+                    if device.md.beamline in optic.branches:
+                        if device.md.beamline not in optic.destination:
+                            block.append(optic)
+                    # Otherwise ensure it is removed from the beamline
+                    elif optic.md.beamline not in optic.destination:
                         block.append(optic)
                 # Clear optics that have been evaluated
                 last_branches.clear()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Correction to make branching logic far easier to specify:

1. Walk beamline remembering the optics that we see
2. When we find a device that is not a new beamline review the optics we've seen. There are two ways a device can be blocking:
* If the optic specifically lists our hutch as a possible destination but it is not presently being delivered there i.e XPP LODCM lists HXD instead of XPP
* If the optic does not list our new beamline as a destination, it must be "passing" beam through along its current path.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Instead of https://github.com/pcdshub/pcdsdevices/pull/291

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Existing tests all pass
* Works on current `lightpath` database
