### PR TITLE
MAINT: Swap to qtpy

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -15,15 +15,16 @@ requirements:
     run:
       - python {{PY_VER}}*,>=3
       - coloredlogs
-      - ophyd
       - happi
       - numpy
-      - prettytable
+      - ophyd
       - pcdsdevices
+      - prettytable
       - pydm
       - pyqt >=5 
-      - typhon
       - qtawesome
+      - qtpy
+      - typhon
 
 test:
     imports:

--- a/lightpath/ui/gui.py
+++ b/lightpath/ui/gui.py
@@ -10,8 +10,8 @@ import numpy as np
 import pcdsdevices.device_types as dtypes
 from pcdsdevices.valve import PPSStopper
 from pydm import Display, PyDMApplication
-from pydm.PyQt.QtCore import pyqtSlot, Qt
-from pydm.PyQt.QtGui import QHBoxLayout, QGridLayout, QCheckBox
+from qtpy.QtCore import Slot as pyqtSlot, Qt
+from qtpy.QtGui import QHBoxLayout, QGridLayout, QCheckBox
 import typhon
 
 from lightpath.path import DeviceState

--- a/lightpath/ui/widgets.py
+++ b/lightpath/ui/widgets.py
@@ -5,8 +5,9 @@ import logging
 import os.path
 
 from pydm import Display
-from pydm.PyQt.QtCore import pyqtSlot, pyqtSignal
-from pydm.PyQt.QtGui import QColor, QBrush, QLabel
+from qtpy.QtCore import Slot as pyqtSlot, Signal as pyqtSignal
+from qtpy.QtGui import QBrush, QColor
+from qtpy.QtWidgets import QLabel
 import qtawesome as qta
 
 from lightpath.path import find_device_state, DeviceState

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,6 @@ pcdsdevices
 prettytable
 pydm
 pyqt
+qtawesome
 qtpy
 typhon

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,5 @@ pcdsdevices
 prettytable
 pydm
 pyqt
+qtpy
 typhon


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Use the `qtpy` abstraction layer for base `PyQt` imports

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
After https://github.com/slaclab/pydm/pull/380 PyDM now uses `qtpy` as its interface layer. There may be a day in which the `PyDM` interface layer is deprecated. This PR prepares us for this day if and when it should arise. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing test suite