### PR TITLE
FIX: include all ui files in build

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
 include versioneer.py
 include lightpath/_version.py
-include lightpath/ui/lightapp.ui
+include lightpath/ui/*.ui


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Include all `.ui` files in this folder, not just `lightapp.ui`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`device.ui` was not included, so the launcher failed in the newest env for the built package. This future-proofs the folder.