### PR TITLE
FIX: Include all ui files in package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
 include versioneer.py
 include lightpath/_version.py
-include lightpath/ui/lightapp.ui
+include lightpath/ui/*.ui


### PR DESCRIPTION
Classic bug! Unfortunately this one snuck into a release. Not packaging `.ui` files properly...