### PR TITLE
FIX: Do not reuse fixture for external use

### DIFF
--- a/lightpath/tests/__init__.py
+++ b/lightpath/tests/__init__.py
@@ -1,1 +1,1 @@
-from .conftest import path, lcls_client  # noqa
+from .conftest import simulated_path as path, lcls_client  # noqa

--- a/lightpath/tests/conftest.py
+++ b/lightpath/tests/conftest.py
@@ -181,8 +181,7 @@ def device():
 
 
 # Basic Beamline
-@pytest.fixture(scope='function')
-def path():
+def simulated_path():
     # Assemble device lists
     devices = [Valve('zero', z=0., beamline='TST'),
                Valve('one', z=2., beamline='TST'),
@@ -196,6 +195,11 @@ def path():
     devices = sorted(devices, key=lambda d: d.prefix)
     # Create beampath
     return BeamPath(*devices, name='TST')
+
+
+@pytest.fixture(scope='function')
+def path():
+    return simulated_path()
 
 
 # Beamline that requires optic insertion


### PR DESCRIPTION
Avoid calling fixture outside of tests. A little sloppy, but this was the quick patch to make it all work with minimal changes.