### PR TITLE
MNT: add LFE line to HXR configs

### DIFF
--- a/lightpath/config.py
+++ b/lightpath/config.py
@@ -4,10 +4,16 @@ Configuration for LCLS beamlines
 post_xrtm2h = 817.2
 xpp_lodcm = 781.2
 
-beamlines = {'XPP': {'HXD': {'end': xpp_lodcm}},
-             'XCS': {'HXD': {}},
-             'PBT': {'HXD': {'end': post_xrtm2h},
+beamlines = {'XPP': {'LFE': {},
+                     'HXD': {'end': xpp_lodcm}},
+             'XCS': {'LFE': {},
+                     'HXD': {}},
+             'PBT': {'LFE': {},
+                     'HXD': {'end': post_xrtm2h},
                      'XCS': {}},
-             'MFX': {'HXD': {'end': post_xrtm2h}},
-             'CXI': {'HXD': {}},
-             'MEC': {'HXD': {'end': post_xrtm2h}}}
+             'MFX': {'LFE': {},
+                     'HXD': {'end': post_xrtm2h}},
+             'CXI': {'LFE': {},
+                     'HXD': {}},
+             'MEC': {'LFE': {},
+                     'HXD': {'end': post_xrtm2h}}}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
The new beamline is called LFE. I've added it here.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is leeched off of in other contexts, like in `hutch-python`...

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Makes xpppython load the devices. Maybe doesn't break this repo's test, haven't checked.