### PR TITLE
ENH: add TMO and RIX lightpath configs

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -18,7 +18,7 @@ requirements:
       - happi >=1.6.0
       - numpy
       - ophyd
-      - pcdsdevices >=2.6.0
+      - pcdsdevices >=3.3.0
       - prettytable
       - pydm
       - pyqt >=5

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -18,7 +18,7 @@ requirements:
       - happi >=1.6.0
       - numpy
       - ophyd
-      - pcdsdevices >=3.3.0
+      - pcdsdevices >=3.4.0
       - prettytable
       - pydm
       - pyqt >=5

--- a/lightpath/config.py
+++ b/lightpath/config.py
@@ -16,4 +16,6 @@ beamlines = {'XPP': {'LFE': {},
              'CXI': {'LFE': {},
                      'HXD': {}},
              'MEC': {'LFE': {},
-                     'HXD': {'end': post_xrtm2h}}}
+                     'HXD': {'end': post_xrtm2h}},
+             'TMO': {'KFE': {}},
+            }

--- a/lightpath/config.py
+++ b/lightpath/config.py
@@ -18,4 +18,5 @@ beamlines = {'XPP': {'LFE': {},
              'MEC': {'LFE': {},
                      'HXD': {'end': post_xrtm2h}},
              'TMO': {'KFE': {}},
-            }
+             'RIX': {'KFE': {}},
+             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Add TMO to lightpath config with instructions to include KFE and RIX

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
KFE devices are part of TMO and RXI's paths
This is also used in hutch python to decide which happi devices to load

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
dev checkout in tmo/rix hutch pythons