### PR TITLE
WIP/ENH: use graphs for path finding, and apply new Lightpath interface

### DIFF
--- a/lightpath/config.py
+++ b/lightpath/config.py
@@ -1,22 +1,15 @@
 """
 Configuration for LCLS beamlines
 """
-post_xrtm2h = 817.2
-xpp_lodcm = 781.2
 
-beamlines = {'XPP': {'LFE': {},
-                     'HXD': {'end': xpp_lodcm}},
-             'XCS': {'LFE': {},
-                     'HXD': {}},
-             'PBT': {'LFE': {},
-                     'HXD': {'end': post_xrtm2h},
-                     'XCS': {}},
-             'MFX': {'LFE': {},
-                     'HXD': {'end': post_xrtm2h}},
-             'CXI': {'LFE': {},
-                     'HXD': {}},
-             'MEC': {'LFE': {},
-                     'HXD': {'end': post_xrtm2h}},
-             'TMO': {'KFE': {}},
-             'RIX': {'KFE': {}},
-             }
+# mapping of endstation to branch name
+beamlines = {'XPP': ['L2', 'L0'],
+             'XCS': ['L3'],
+             'MFX': ['L5'],
+             'CXI': ['L0'],
+             'MEC': ['L4'],
+             'TMO': ['K4'],
+             'CRIX': ['K1'],
+             'qRIX': ['K2'],
+             'TXI': ['K3, L1'],
+             'sources': ['K0', 'L0']}

--- a/lightpath/config.py
+++ b/lightpath/config.py
@@ -11,5 +11,5 @@ beamlines = {'XPP': ['L2', 'L0'],
              'TMO': ['K4'],
              'CRIX': ['K1'],
              'qRIX': ['K2'],
-             'TXI': ['K3, L1'],
-             'sources': ['K0', 'L0']}
+             'TXI': ['K3', 'L1']}
+sources = ['K0', 'L0']

--- a/lightpath/controller.py
+++ b/lightpath/controller.py
@@ -13,7 +13,7 @@ import math
 
 import networkx as nx
 
-from .config import beamlines
+from .config import beamlines, sources
 from .path import BeamPath
 
 logger = logging.getLogger(__name__)
@@ -78,7 +78,7 @@ class LightController:
         subgraphs = []
         for branch_name, branch_devs in branch_dict.items():
             subgraph = BeamPath.make_graph(branch_devs,
-                                           sources=beamlines['sources'],
+                                           sources=sources,
                                            branch_name=branch_name)
             self.sources.update((n for n in subgraph if 'source' in n))
             subgraphs.append(subgraph)

--- a/lightpath/happi/containers.py
+++ b/lightpath/happi/containers.py
@@ -1,0 +1,32 @@
+"""
+Define subclasses of Happi Items for use with Lightpath
+"""
+import re
+from copy import deepcopy
+
+from happi.item import EntryInfo, OphydItem
+
+
+class LightpathItem(OphydItem):
+    name = EntryInfo(('Shorthand Python-valid name for the Python instance. '
+                      'Must be between 3 and 80 characters.'),
+                     optional=False,
+                     enforce=re.compile(r'[a-z][a-z\_0-9]{2,78}$'))
+    kwargs = deepcopy(OphydItem.kwargs)
+    kwargs.default = {'name': '{{name}}',
+                      'input_branches': '{{input_branches}}',
+                      'output_branches': '{{output_branches}}',
+                      }
+    z = EntryInfo('Beamline position of the device',
+                  enforce=float, default=-1.0)
+    lightpath = EntryInfo("If the device should be included in the "
+                          "LCLS Lightpath", enforce=bool, default=False,
+                          optional=False)
+    active = EntryInfo("If the device is currently active",
+                       optional=False, enforce=bool, default=False)
+    input_branches = EntryInfo(('List of branches the device can receive '
+                                'beam from.'),
+                               optional=False, enforce=list)
+    output_branches = EntryInfo(('List of branches the device can deliver '
+                                'beam to.'),
+                                optional=False, enforce=list)

--- a/lightpath/path.py
+++ b/lightpath/path.py
@@ -484,7 +484,7 @@ class BeamPath(OphydObject):
         else:
             block = math.inf
         # If device is upstream of impediment
-        if obj and obj.md.z <= block:
+        if obj and obj.parent.md.z <= block:
             self._run_subs(sub_type=self.SUB_PTH_CHNG, device=obj)
 
     def subscribe(self, cb, event_type=None, run=True):
@@ -507,9 +507,10 @@ class BeamPath(OphydObject):
             for dev in self.devices:
                 # Add callback here!
                 try:
-                    dev.subscribe(self._device_moved,
-                                  event_type=dev.SUB_STATE,
-                                  run=False)
+                    dev.lp_summary.subscribe(self._device_moved,
+                                             run=False)
+                    # get once to initialize SummarySignal
+                    dev.lp_summary.get()
                 except Exception:
                     logger.error("BeamPath is unable to subscribe "
                                  "to device %s", dev.name)

--- a/lightpath/tests/conftest.py
+++ b/lightpath/tests/conftest.py
@@ -66,7 +66,7 @@ class Valve(Device):
     _icon = 'fa.adjust'
 
     current_state = Cpt(AttributeSignal,
-                        attr='_current_state',
+                        attr='status',
                         kind=Kind.hinted)
     current_transmission = Cpt(AttributeSignal,
                                attr='_transmission',
@@ -75,7 +75,7 @@ class Valve(Device):
                               attr='_current_destination',
                               kind=Kind.hinted)
 
-    lp_signal = Cpt(SummarySignal, name='lp_summary')
+    lp_summary = Cpt(SummarySignal, name='lp_summary')
 
     lightpath_cpts = ['current_state', 'current_transmission',
                       'current_destination']
@@ -88,7 +88,7 @@ class Valve(Device):
         self.output_branches = output_branches
         self.status = Status.removed
         for sig in self.lightpath_cpts:
-            self.lp_signal.add_signal_by_attr_name(sig)
+            self.lp_summary.add_signal_by_attr_name(sig)
 
     @property
     def _current_destination(self):
@@ -117,8 +117,8 @@ class Valve(Device):
         """
         Insert the device into the beampath
         """
-        # Complete request
-        self.status = Status.inserted
+        # Complete request s.t. callbacks run
+        self.current_state.put(Status.inserted)
         # Run subscriptions to device state
         self._run_subs(obj=self, sub_type=self._default_sub)
         # Return complete status object
@@ -129,7 +129,7 @@ class Valve(Device):
         Remove the device from the beampath
         """
         # Complete request
-        self.status = Status.removed
+        self.current_state.put(Status.removed)
         # Run subscriptions to device state
         self._run_subs(obj=self, sub_type=self._default_sub)
         # Return complete status object

--- a/lightpath/tests/path.json
+++ b/lightpath/tests/path.json
@@ -1,445 +1,659 @@
 {
-    "fee_valve1": {
-        "_id": "fee_valve1",
+    "al1k2": {
+        "_id": "al1k2",
         "active": true,
         "args": [
-            "{{name}}"
+            "{{prefix}}"
         ],
-        "beamline": "HXR",
-        "creation": "Sun Feb 11 11:46:18 2018",
+        "creation": "Wed Jun 22 09:53:23 2022",
         "device_class": "lightpath.tests.conftest.Valve",
+        "documentation": null,
+        "input_branches": [
+            "K2"
+        ],
         "kwargs": {
-            "beamline": "{{beamline}}",
+            "input_branches": "{{input_branches}}",
+            "output_branches": "{{output_branches}}",
             "z": "{{z}}"
         },
-        "last_edit": "Tue Feb 13 09:35:09 2018",
+        "last_edit": "Wed Jun 22 09:53:23 2022",
         "lightpath": true,
-        "macros": null,
-        "name": "fee_valve1",
-        "parent": null,
-        "prefix": "fee_valve1",
-        "screen": null,
-        "stand": null,
-        "system": null,
-        "type": "Device",
-        "z": 0.0
+        "name": "al1k2",
+        "output_branches": [
+            "K2"
+        ],
+        "prefix": "AL1K2:L2SI",
+        "type": "lightpath.happi.containers.LightpathItem",
+        "z": 778.833
     },
-    "fee_valve2": {
-        "_id": "fee_valve2",
+    "at1k4": {
+        "_id": "at1k4",
         "active": true,
         "args": [
-            "{{name}}"
+            "{{prefix}}"
         ],
-        "beamline": "HXR",
-        "creation": "Sun Feb 11 11:46:18 2018",
+        "creation": "Wed Jun 22 09:53:23 2022",
         "device_class": "lightpath.tests.conftest.Valve",
+        "documentation": null,
+        "input_branches": [
+            "K4"
+        ],
         "kwargs": {
-            "beamline": "{{beamline}}",
+            "input_branches": "{{input_branches}}",
+            "output_branches": "{{output_branches}}",
             "z": "{{z}}"
         },
-        "last_edit": "Tue Feb 13 09:35:09 2018",
+        "last_edit": "Wed Jun 22 09:53:23 2022",
         "lightpath": true,
-        "macros": null,
-        "name": "fee_valve2",
-        "parent": null,
-        "prefix": "fee_valve2",
-        "screen": null,
-        "stand": null,
-        "system": null,
-        "type": "Device",
-        "z": 2.0
+        "name": "at1k4",
+        "output_branches": [
+            "K4"
+        ],
+        "prefix": "AT1K4:L2SI",
+        "type": "lightpath.happi.containers.LightpathItem",
+        "z": 748.0
     },
-    "hxr_ipm": {
-        "_id": "hxr_ipm",
+    "im1k0": {
+        "_id": "im1k0",
         "active": true,
         "args": [
-            "{{name}}"
+            "{{prefix}}"
         ],
-        "beamline": "CXI",
-        "creation": "Sun Feb 11 11:46:18 2018",
+        "creation": "Wed Jun 22 09:53:22 2022",
         "device_class": "lightpath.tests.conftest.IPIMB",
+        "documentation": null,
+        "input_branches": [
+            "K0"
+        ],
         "kwargs": {
-            "beamline": "{{beamline}}",
+            "input_branches": "{{input_branches}}",
+            "output_branches": "{{output_branches}}",
             "z": "{{z}}"
         },
-        "last_edit": "Tue Feb 13 09:35:09 2018",
+        "last_edit": "Wed Jun 22 09:53:22 2022",
         "lightpath": true,
-        "macros": null,
-        "name": "hxr_ipm",
-        "parent": null,
-        "prefix": "hxr_ipm",
-        "screen": null,
-        "stand": null,
-        "system": null,
-        "type": "Device",
-        "z": 24.0
+        "name": "im1k0",
+        "output_branches": [
+            "K0"
+        ],
+        "prefix": "IM1K0:XTES",
+        "type": "lightpath.happi.containers.LightpathItem",
+        "z": 699.5
     },
-    "hxr_valve": {
-        "_id": "hxr_valve",
+    "im1k1": {
+        "_id": "im1k1",
         "active": true,
         "args": [
-            "{{name}}"
+            "{{prefix}}"
         ],
-        "beamline": "CXI",
-        "creation": "Sun Feb 11 11:46:18 2018",
-        "device_class": "lightpath.tests.conftest.Valve",
-        "kwargs": {
-            "beamline": "{{beamline}}",
-            "z": "{{z}}"
-        },
-        "last_edit": "Tue Feb 13 09:35:09 2018",
-        "lightpath": true,
-        "macros": null,
-        "name": "hxr_valve",
-        "parent": null,
-        "prefix": "hxr_valve",
-        "screen": null,
-        "stand": null,
-        "system": null,
-        "type": "Device",
-        "z": 25.0
-    },
-    "mec_ipm": {
-        "_id": "mec_ipm",
-        "active": true,
-        "args": [
-            "{{name}}"
-        ],
-        "beamline": "MEC",
-        "creation": "Sun Feb 11 11:46:19 2018",
+        "creation": "Wed Jun 22 09:53:23 2022",
         "device_class": "lightpath.tests.conftest.IPIMB",
+        "documentation": null,
+        "input_branches": [
+            "K1"
+        ],
         "kwargs": {
-            "beamline": "{{beamline}}",
+            "input_branches": "{{input_branches}}",
+            "output_branches": "{{output_branches}}",
             "z": "{{z}}"
         },
-        "last_edit": "Tue Feb 13 09:35:09 2018",
+        "last_edit": "Wed Jun 22 09:53:23 2022",
         "lightpath": true,
-        "macros": null,
-        "name": "mec_ipm",
-        "parent": null,
-        "prefix": "mec_ipm",
-        "screen": null,
-        "stand": null,
-        "system": null,
-        "type": "Device",
-        "z": 24.0
+        "name": "im1k1",
+        "output_branches": [
+            "K1"
+        ],
+        "prefix": "IM1K1:PPM",
+        "type": "lightpath.happi.containers.LightpathItem",
+        "z": 738.0
     },
-    "mec_valve": {
-        "_id": "mec_valve",
+    "im1k2": {
+        "_id": "im1k2",
         "active": true,
         "args": [
-            "{{name}}"
+            "{{prefix}}"
         ],
-        "beamline": "MEC",
-        "creation": "Sun Feb 11 11:46:19 2018",
-        "device_class": "lightpath.tests.conftest.Valve",
-        "kwargs": {
-            "beamline": "{{beamline}}",
-            "z": "{{z}}"
-        },
-        "last_edit": "Tue Feb 13 09:35:09 2018",
-        "lightpath": true,
-        "macros": null,
-        "name": "mec_valve",
-        "parent": null,
-        "prefix": "mec_valve",
-        "screen": null,
-        "stand": null,
-        "system": null,
-        "type": "Device",
-        "z": 25.0
-    },
-    "s2_stopper": {
-        "_id": "s2_stopper",
-        "active": true,
-        "args": [
-            "{{name}}"
-        ],
-        "beamline": "HXR",
-        "creation": "Sun Feb 11 11:46:18 2018",
-        "device_class": "lightpath.tests.conftest.Stopper",
-        "kwargs": {
-            "beamline": "{{beamline}}",
-            "z": "{{z}}"
-        },
-        "last_edit": "Tue Feb 13 09:35:09 2018",
-        "lightpath": true,
-        "macros": null,
-        "name": "s2_stopper",
-        "parent": null,
-        "prefix": "s2_stopper",
-        "screen": null,
-        "stand": null,
-        "system": null,
-        "type": "Device",
-        "z": 9.0
-    },
-    "s4_stopper": {
-        "_id": "s4_stopper",
-        "active": true,
-        "args": [
-            "{{name}}"
-        ],
-        "beamline": "XCS",
-        "creation": "Sun Feb 11 11:46:18 2018",
-        "device_class": "lightpath.tests.conftest.Stopper",
-        "kwargs": {
-            "beamline": "{{beamline}}",
-            "z": "{{z}}"
-        },
-        "last_edit": "Tue Feb 13 09:35:09 2018",
-        "lightpath": true,
-        "macros": null,
-        "name": "s4_stopper",
-        "parent": null,
-        "prefix": "s4_stopper",
-        "screen": null,
-        "stand": null,
-        "system": null,
-        "type": "Device",
-        "z": 32.0
-    },
-    "s5_stopper": {
-        "_id": "s5_stopper",
-        "active": true,
-        "args": [
-            "{{name}}"
-        ],
-        "beamline": "CXI",
-        "creation": "Sun Feb 11 11:46:18 2018",
-        "device_class": "lightpath.tests.conftest.Stopper",
-        "kwargs": {
-            "beamline": "{{beamline}}",
-            "z": "{{z}}"
-        },
-        "last_edit": "Tue Feb 13 09:35:09 2018",
-        "lightpath": true,
-        "macros": null,
-        "name": "s5_stopper",
-        "parent": null,
-        "prefix": "s5_stopper",
-        "screen": null,
-        "stand": null,
-        "system": null,
-        "type": "Device",
-        "z": 31.0
-    },
-    "s6_stopper": {
-        "_id": "s6_stopper",
-        "active": true,
-        "args": [
-            "{{name}}"
-        ],
-        "beamline": "MEC",
-        "creation": "Sun Feb 11 11:46:18 2018",
-        "device_class": "lightpath.tests.conftest.Stopper",
-        "kwargs": {
-            "beamline": "{{beamline}}",
-            "z": "{{z}}"
-        },
-        "last_edit": "Tue Feb 13 09:35:09 2018",
-        "lightpath": true,
-        "macros": null,
-        "name": "s6_stopper",
-        "parent": null,
-        "prefix": "s6_stopper",
-        "screen": null,
-        "stand": null,
-        "system": null,
-        "type": "Device",
-        "z": 30.0
-    },
-    "tst_broke": {
-        "_id": "tst_broke",
-        "active": true,
-        "args": [
-            "{{name}}"
-        ],
-        "beamline": "FEE",
-        "creation": "Mon Feb 12 14:26:54 2018",
-        "device_class": null,
-        "kwargs": {
-            "beamline": "{{beamline}}",
-            "z": "{{z}}"
-        },
-        "last_edit": "Tue Feb 13 09:35:09 2018",
-        "lightpath": true,
-        "macros": null,
-        "name": "Broken",
-        "parent": null,
-        "prefix": "tst_broke",
-        "screen": null,
-        "stand": null,
-        "system": null,
-        "type": "Device",
-        "z": 3.0
-    },
-    "xcs_ipm": {
-        "_id": "xcs_ipm",
-        "active": true,
-        "args": [
-            "{{name}}"
-        ],
-        "beamline": "XCS",
-        "creation": "Sun Feb 11 11:46:19 2018",
+        "creation": "Wed Jun 22 09:53:23 2022",
         "device_class": "lightpath.tests.conftest.IPIMB",
+        "documentation": null,
+        "input_branches": [
+            "K2"
+        ],
         "kwargs": {
-            "beamline": "{{beamline}}",
+            "input_branches": "{{input_branches}}",
+            "output_branches": "{{output_branches}}",
             "z": "{{z}}"
         },
-        "last_edit": "Tue Feb 13 09:35:09 2018",
+        "last_edit": "Wed Jun 22 09:53:23 2022",
         "lightpath": true,
-        "macros": null,
-        "name": "xcs_ipm",
-        "parent": null,
-        "prefix": "xcs_ipm",
-        "screen": null,
-        "stand": null,
-        "system": null,
-        "type": "Device",
-        "z": 21.0
+        "name": "im1k2",
+        "output_branches": [
+            "K2"
+        ],
+        "prefix": "IM1K2:PPM",
+        "type": "lightpath.happi.containers.LightpathItem",
+        "z": 777.9
     },
-    "xcs_valve": {
-        "_id": "xcs_valve",
+    "im1k3": {
+        "_id": "im1k3",
         "active": true,
         "args": [
-            "{{name}}"
+            "{{prefix}}"
         ],
-        "beamline": "XCS",
-        "creation": "Sun Feb 11 11:46:19 2018",
-        "device_class": "lightpath.tests.conftest.Valve",
-        "kwargs": {
-            "beamline": "{{beamline}}",
-            "z": "{{z}}"
-        },
-        "last_edit": "Tue Feb 13 09:35:09 2018",
-        "lightpath": true,
-        "macros": null,
-        "name": "xcs_valve",
-        "parent": null,
-        "prefix": "xcs_valve",
-        "screen": null,
-        "stand": null,
-        "system": null,
-        "type": "Device",
-        "z": 22.0
-    },
-    "xrt_ipm": {
-        "_id": "xrt_ipm",
-        "active": true,
-        "args": [
-            "{{name}}"
-        ],
-        "beamline": "HXR",
-        "creation": "Sun Feb 11 11:46:18 2018",
+        "creation": "Wed Jun 22 09:53:23 2022",
         "device_class": "lightpath.tests.conftest.IPIMB",
+        "documentation": null,
+        "input_branches": [
+            "K3"
+        ],
         "kwargs": {
-            "beamline": "{{beamline}}",
+            "input_branches": "{{input_branches}}",
+            "output_branches": "{{output_branches}}",
             "z": "{{z}}"
         },
-        "last_edit": "Tue Feb 13 09:35:09 2018",
+        "last_edit": "Wed Jun 22 09:53:23 2022",
         "lightpath": true,
-        "macros": null,
-        "name": "xrt_ipm",
-        "parent": null,
-        "prefix": "xrt_ipm",
-        "screen": null,
-        "stand": null,
-        "system": null,
-        "type": "Device",
-        "z": 15.0
+        "name": "im1k3",
+        "output_branches": [
+            "K3"
+        ],
+        "prefix": "IM1K3:PPM",
+        "type": "lightpath.happi.containers.LightpathItem",
+        "z": 740.8
     },
-    "xrt_m1h": {
-        "_id": "xrt_m1h",
+    "im1k4": {
+        "_id": "im1k4",
         "active": true,
         "args": [
-            "{{name}}"
+            "{{prefix}}"
         ],
-        "beamline": "HXR",
-        "creation": "Sun Feb 11 11:46:18 2018",
+        "creation": "Wed Jun 22 09:53:24 2022",
+        "device_class": "pcdsdevices.pim.XPIM",
+        "documentation": null,
+        "input_branches": [
+            "K4"
+        ],
+        "kwargs": {
+            "input_branches": "{{input_branches}}",
+            "output_branches": "{{output_branches}}",
+            "z": "{{z}}"
+        },
+        "last_edit": "Wed Jun 22 09:53:24 2022",
+        "lightpath": true,
+        "name": "im1k4",
+        "output_branches": [
+            "K4"
+        ],
+        "prefix": "IM1K4:XTES",
+        "type": "lightpath.happi.containers.LightpathItem",
+        "z": 750.3
+    },
+    "im2k1": {
+        "_id": "im2k1",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "creation": "Wed Jun 22 09:53:23 2022",
+        "device_class": "lightpath.tests.conftest.IPIMB",
+        "documentation": null,
+        "input_branches": [
+            "K1"
+        ],
+        "kwargs": {
+            "input_branches": "{{input_branches}}",
+            "output_branches": "{{output_branches}}",
+            "z": "{{z}}"
+        },
+        "last_edit": "Wed Jun 22 09:53:23 2022",
+        "lightpath": true,
+        "name": "im2k1",
+        "output_branches": [
+            "K1"
+        ],
+        "prefix": "IM2K1:PPM",
+        "type": "lightpath.happi.containers.LightpathItem",
+        "z": 742.15
+    },
+    "im2k2": {
+        "_id": "im2k2",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "creation": "Wed Jun 22 09:53:23 2022",
+        "device_class": "lightpath.tests.conftest.IPIMB",
+        "documentation": null,
+        "input_branches": [
+            "K2"
+        ],
+        "kwargs": {
+            "input_branches": "{{input_branches}}",
+            "output_branches": "{{output_branches}}",
+            "z": "{{z}}"
+        },
+        "last_edit": "Wed Jun 22 09:53:23 2022",
+        "lightpath": true,
+        "name": "im2k2",
+        "output_branches": [
+            "K2"
+        ],
+        "prefix": "IM2K2:PPM",
+        "type": "lightpath.happi.containers.LightpathItem",
+        "z": 780.45
+    },
+    "im4k4": {
+        "_id": "im4k4",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "creation": "Wed Jun 22 09:53:24 2022",
+        "device_class": "lightpath.tests.conftest.IPIMB",
+        "documentation": null,
+        "input_branches": [
+            "K4"
+        ],
+        "kwargs": {
+            "input_branches": "{{input_branches}}",
+            "output_branches": "{{output_branches}}",
+            "z": "{{z}}"
+        },
+        "last_edit": "Wed Jun 22 09:53:24 2022",
+        "lightpath": true,
+        "name": "im4k4",
+        "output_branches": [
+            "K4"
+        ],
+        "prefix": "IM4K4:PPM",
+        "type": "lightpath.happi.containers.LightpathItem",
+        "z": 761.101
+    },
+    "mr1k1_bend": {
+        "_id": "mr1k1_bend",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "creation": "Wed Jun 22 09:53:21 2022",
         "device_class": "lightpath.tests.conftest.Crystal",
+        "documentation": null,
+        "input_branches": [
+            "K0"
+        ],
         "kwargs": {
-            "beamline": "{{beamline}}",
-            "states": [
-                [
-                    "MEC",
-                    "CXI"
-                ],
-                [
-                    "XCS"
-                ]
-            ],
+            "input_branches": "{{input_branches}}",
+            "output_branches": "{{output_branches}}",
             "z": "{{z}}"
         },
-        "last_edit": "Tue Feb 13 09:37:21 2018",
+        "last_edit": "Wed Jun 22 09:53:21 2022",
         "lightpath": true,
-        "macros": null,
-        "name": "xrt_m1h",
-        "parent": null,
-        "prefix": "xrt_m1h",
-        "screen": null,
-        "stand": null,
-        "system": null,
-        "type": "Device",
-        "z": 16.0
+        "name": "mr1k1_bend",
+        "output_branches": [
+            "K0",
+            "K1"
+        ],
+        "prefix": "MR1K1:BEND",
+        "type": "lightpath.happi.containers.LightpathItem",
+        "z": 733.772
     },
-    "xrt_m2h": {
-        "_id": "xrt_m2h",
+    "mr1k2_switch": {
+        "_id": "mr1k2_switch",
         "active": true,
         "args": [
-            "{{name}}"
+            "{{prefix}}"
         ],
-        "beamline": "HXR",
-        "creation": "Sun Feb 11 11:46:18 2018",
+        "creation": "Wed Jun 22 09:53:21 2022",
         "device_class": "lightpath.tests.conftest.Crystal",
+        "documentation": null,
+        "input_branches": [
+            "K1"
+        ],
         "kwargs": {
-            "beamline": "{{beamline}}",
-            "states": [
-                [
-                    "CXI",
-                    "XCS"
-                ],
-                [
-                    "MEC"
-                ]
-            ],
+            "input_branches": "{{input_branches}}",
+            "output_branches": "{{output_branches}}",
             "z": "{{z}}"
         },
-        "last_edit": "Tue Feb 13 09:37:46 2018",
+        "last_edit": "Wed Jun 22 09:53:21 2022",
         "lightpath": true,
-        "macros": null,
-        "name": "xrt_m2h",
-        "parent": null,
-        "prefix": "xrt_m2h",
-        "screen": null,
-        "stand": null,
-        "system": null,
-        "type": "Device",
-        "z": 20.0
+        "name": "mr1k2_switch",
+        "output_branches": [
+            "K1",
+            "K2"
+        ],
+        "prefix": "MR1K2:SWITCH",
+        "type": "lightpath.happi.containers.LightpathItem",
+        "z": 742.922
     },
-    "xrt_valve": {
-        "_id": "xrt_valve",
+    "mr1k3_vgc_1": {
+        "_id": "mr1k3_vgc_1",
         "active": true,
         "args": [
-            "{{name}}"
+            "{{prefix}}"
         ],
-        "beamline": "HXR",
-        "creation": "Sun Feb 11 11:46:18 2018",
-        "device_class": "lightpath.tests.conftest.Valve",
+        "creation": "Wed Jun 22 09:53:21 2022",
+        "device_class": "lightpath.tests.conftest.Crystal",
+        "documentation": null,
+        "input_branches": [
+            "K0"
+        ],
         "kwargs": {
-            "beamline": "{{beamline}}",
+            "input_branches": "{{input_branches}}",
+            "output_branches": "{{output_branches}}",
             "z": "{{z}}"
         },
-        "last_edit": "Tue Feb 13 09:35:09 2018",
+        "last_edit": "Wed Jun 22 09:53:21 2022",
         "lightpath": true,
-        "macros": null,
-        "name": "xrt_valve",
-        "parent": null,
-        "prefix": "xrt_valve",
-        "screen": null,
-        "stand": null,
-        "system": null,
-        "type": "Device",
-        "z": 18.0
+        "name": "mr1k3_vgc_1",
+        "output_branches": [
+            "K0",
+            "K3"
+        ],
+        "prefix": "MR1K3:VGC:1",
+        "type": "lightpath.happi.containers.LightpathItem",
+        "z": 734.4617237
+    },
+    "mr1k4_soms": {
+        "_id": "mr1k4_soms",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "creation": "Wed Jun 22 09:53:21 2022",
+        "device_class": "lightpath.tests.conftest.Crystal",
+        "documentation": null,
+        "input_branches": [
+            "K0"
+        ],
+        "kwargs": {
+            "input_branches": "{{input_branches}}",
+            "output_branches": "{{output_branches}}",
+            "z": "{{z}}"
+        },
+        "last_edit": "Wed Jun 22 09:53:21 2022",
+        "lightpath": true,
+        "name": "mr1k4_soms",
+        "output_branches": [
+            "K4"
+        ],
+        "prefix": "MR1K4:SOMS",
+        "type": "lightpath.happi.containers.LightpathItem",
+        "z": 745.72
+    },
+    "mr1l0_homs": {
+        "_id": "mr1l0_homs",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "creation": "Wed Jun 22 09:53:22 2022",
+        "device_class": "lightpath.tests.conftest.Crystal",
+        "documentation": null,
+        "input_branches": [
+            "L0"
+        ],
+        "kwargs": {
+            "input_branches": "{{input_branches}}",
+            "output_branches": "{{output_branches}}",
+            "z": "{{z}}"
+        },
+        "last_edit": "Wed Jun 22 09:53:22 2022",
+        "lightpath": true,
+        "name": "mr1l0_homs",
+        "output_branches": [
+            "L0",
+            "L1"
+        ],
+        "prefix": "MR1L0:HOMS",
+        "type": "lightpath.happi.containers.LightpathItem",
+        "z": 740.0
+    },
+    "mr1l3_homs": {
+        "_id": "mr1l3_homs",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "creation": "Wed Jun 22 09:53:22 2022",
+        "device_class": "lightpath.tests.conftest.Crystal",
+        "documentation": null,
+        "input_branches": [
+            "L0"
+        ],
+        "kwargs": {
+            "input_branches": "{{input_branches}}",
+            "output_branches": "{{output_branches}}",
+            "z": "{{z}}"
+        },
+        "last_edit": "Wed Jun 22 09:53:22 2022",
+        "lightpath": true,
+        "name": "mr1l3_homs",
+        "output_branches": [
+            "L0",
+            "L3"
+        ],
+        "prefix": "MR1L3:HOMS",
+        "type": "lightpath.happi.containers.LightpathItem",
+        "z": 814.716
+    },
+    "mr1l4_homs": {
+        "_id": "mr1l4_homs",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "creation": "Wed Jun 22 09:53:22 2022",
+        "device_class": "lightpath.tests.conftest.Crystal",
+        "documentation": null,
+        "input_branches": [
+            "L0"
+        ],
+        "kwargs": {
+            "input_branches": "{{input_branches}}",
+            "output_branches": "{{output_branches}}",
+            "z": "{{z}}"
+        },
+        "last_edit": "Wed Jun 22 09:53:22 2022",
+        "lightpath": true,
+        "name": "mr1l4_homs",
+        "output_branches": [
+            "L0",
+            "L4",
+            "L5"
+        ],
+        "prefix": "MR1L4:HOMS",
+        "type": "lightpath.happi.containers.LightpathItem",
+        "z": 817.116
+    },
+    "sl1k0": {
+        "_id": "sl1k0",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "creation": "Wed Jun 22 09:53:22 2022",
+        "device_class": "lightpath.tests.conftest.Stopper",
+        "documentation": null,
+        "input_branches": [
+            "K0"
+        ],
+        "kwargs": {
+            "input_branches": "{{input_branches}}",
+            "output_branches": "{{output_branches}}",
+            "z": "{{z}}"
+        },
+        "last_edit": "Wed Jun 22 09:53:22 2022",
+        "lightpath": true,
+        "name": "sl1k0",
+        "output_branches": [
+            "K0"
+        ],
+        "prefix": "SL1K0:POWER",
+        "type": "lightpath.happi.containers.LightpathItem",
+        "z": 705.86
+    },
+    "sl1k2": {
+        "_id": "sl1k2",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "creation": "Wed Jun 22 09:53:22 2022",
+        "device_class": "lightpath.tests.conftest.Stopper",
+        "documentation": null,
+        "input_branches": [
+            "K2"
+        ],
+        "kwargs": {
+            "input_branches": "{{input_branches}}",
+            "output_branches": "{{output_branches}}",
+            "z": "{{z}}"
+        },
+        "last_edit": "Wed Jun 22 09:53:22 2022",
+        "lightpath": true,
+        "name": "sl1k2",
+        "output_branches": [
+            "K2"
+        ],
+        "prefix": "SL1K2:EXIT",
+        "type": "lightpath.happi.containers.LightpathItem",
+        "z": 759.122
+    },
+    "sl2k2": {
+        "_id": "sl2k2",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "creation": "Wed Jun 22 09:53:23 2022",
+        "device_class": "lightpath.tests.conftest.Stopper",
+        "documentation": null,
+        "input_branches": [
+            "K2"
+        ],
+        "kwargs": {
+            "input_branches": "{{input_branches}}",
+            "output_branches": "{{output_branches}}",
+            "z": "{{z}}"
+        },
+        "last_edit": "Wed Jun 22 09:53:23 2022",
+        "lightpath": true,
+        "name": "sl2k2",
+        "output_branches": [
+            "K2"
+        ],
+        "prefix": "SL2K2:SCATTER",
+        "type": "lightpath.happi.containers.LightpathItem",
+        "z": 765.1
+    },
+    "sl2k4": {
+        "_id": "sl2k4",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "creation": "Wed Jun 22 09:53:24 2022",
+        "device_class": "lightpath.tests.conftest.Stopper",
+        "documentation": null,
+        "input_branches": [
+            "K4"
+        ],
+        "kwargs": {
+            "input_branches": "{{input_branches}}",
+            "output_branches": "{{output_branches}}",
+            "z": "{{z}}"
+        },
+        "last_edit": "Wed Jun 22 09:53:24 2022",
+        "lightpath": true,
+        "name": "sl2k4",
+        "output_branches": [
+            "K4"
+        ],
+        "prefix": "SL2K4:SCATTER",
+        "type": "lightpath.happi.containers.LightpathItem",
+        "z": 767.204
+    },
+    "sp1k1_mono": {
+        "_id": "sp1k1_mono",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "creation": "Wed Jun 22 09:53:23 2022",
+        "device_class": "lightpath.tests.conftest.Stopper",
+        "documentation": null,
+        "input_branches": [
+            "K1"
+        ],
+        "kwargs": {
+            "input_branches": "{{input_branches}}",
+            "output_branches": "{{output_branches}}",
+            "z": "{{z}}"
+        },
+        "last_edit": "Wed Jun 22 09:53:23 2022",
+        "lightpath": true,
+        "name": "sp1k1_mono",
+        "output_branches": [
+            "K1"
+        ],
+        "prefix": "SP1K1:MONO",
+        "type": "lightpath.happi.containers.LightpathItem",
+        "z": 739.622
+    },
+    "xcs_lodcm": {
+        "_id": "xcs_lodcm",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "creation": "Wed Jun 22 09:53:22 2022",
+        "device_class": "lightpath.tests.conftest.Crystal",
+        "documentation": null,
+        "input_branches": [
+            "L0"
+        ],
+        "kwargs": {
+            "input_branches": "{{input_branches}}",
+            "output_branches": "{{output_branches}}",
+            "z": "{{z}}"
+        },
+        "last_edit": "Wed Jun 22 09:53:22 2022",
+        "lightpath": true,
+        "name": "xcs_lodcm",
+        "output_branches": [
+            "L0",
+            "L3"
+        ],
+        "prefix": "XCS:LODCM",
+        "type": "lightpath.happi.containers.LightpathItem",
+        "z": 964.76
+    },
+    "xpp_lodcm": {
+        "_id": "xpp_lodcm",
+        "active": true,
+        "args": [
+            "{{prefix}}"
+        ],
+        "creation": "Wed Jun 22 09:53:22 2022",
+        "device_class": "lightpath.tests.conftest.Crystal",
+        "documentation": null,
+        "input_branches": [
+            "L0"
+        ],
+        "kwargs": {
+            "input_branches": "{{input_branches}}",
+            "output_branches": "{{output_branches}}",
+            "z": "{{z}}"
+        },
+        "last_edit": "Wed Jun 22 09:53:22 2022",
+        "lightpath": true,
+        "name": "xpp_lodcm",
+        "output_branches": [
+            "L0",
+            "L2"
+        ],
+        "prefix": "XPP:LODCM",
+        "type": "lightpath.happi.containers.LightpathItem",
+        "z": 781.1
     }
 }

--- a/lightpath/tests/test_path.py
+++ b/lightpath/tests/test_path.py
@@ -132,7 +132,7 @@ def test_ignore(path):
 
     # Ignore passive devices in addition
     target, ignore = path._ignore(path.path[3], passive=False)
-    assert ignore == [path.path[5], path.path[3]]
+    assert ignore == [path.path[5], path.path[4], path.path[3]]
     assert path.path[3] not in target
     assert path.path[5] not in target
 
@@ -187,49 +187,50 @@ def test_callback(path):
     # Assert callback has been run
     assert cb.called
 
-
-def test_complex_branching(lcls):
-    # Upstream Optic
-    xcs = [d for d in lcls if d.md.beamline in ['HXR', 'XCS']]
-    bp = BeamPath(*xcs)
-    # Remove all the devices
-    for d in xcs:
-        d.remove()
-    # OffsetMirror should be blocking
-    assert bp.impediment == xcs[4]
-    # Insert OffsetMirror
-    bp.path[4].insert()
-    # Path should be cleared
-    assert bp.blocking_devices == []
-    # Downstream Optic
-    mec = [d for d in lcls if d.md.beamline in ['HXR', 'MEC']]
-    bp = BeamPath(*mec)
-    # Remove all devices
-    for d in mec:
-        d.remove()
-    # Path should be cleared
-    assert bp.impediment == mec[6]
-    # Insert first mirror
-    bp.path[4].insert()
-    assert bp.impediment == mec[4]
-    # Insert second mirror
-    bp.path[6].insert()
-    assert bp.impediment == mec[4]
-    # Retract first mirror
-    bp.path[4].remove()
-    assert bp.blocking_devices == []
+# # Involves separating devices into different paths before BP creation
+# # TODO: Should involve controller, which determines logic
+# def test_complex_branching(lcls):
+#     # Upstream Optic
+#     xcs = [d for d in lcls if d.md.beamline in ['HXR', 'XCS']]
+#     bp = BeamPath(*xcs)
+#     # Remove all the devices
+#     for d in xcs:
+#         d.remove()
+#     # OffsetMirror should be blocking
+#     assert bp.impediment == xcs[4]
+#     # Insert OffsetMirror
+#     bp.path[4].insert()
+#     # Path should be cleared
+#     assert bp.blocking_devices == []
+#     # Downstream Optic
+#     mec = [d for d in lcls if d.md.beamline in ['HXR', 'MEC']]
+#     bp = BeamPath(*mec)
+#     # Remove all devices
+#     for d in mec:
+#         d.remove()
+#     # Path should be cleared
+#     assert bp.impediment == mec[6]
+#     # Insert first mirror
+#     bp.path[4].insert()
+#     assert bp.impediment == mec[4]
+#     # Insert second mirror
+#     bp.path[6].insert()
+#     assert bp.impediment == mec[4]
+#     # Retract first mirror
+#     bp.path[4].remove()
+#     assert bp.blocking_devices == []
 
 
 known_table = """\
-+-------+--------+----------+----------+---------+
-| Name  | Prefix | Position | Beamline |   State |
-+-------+--------+----------+----------+---------+
-| zero  | zero   |  0.00000 |      TST | Removed |
-| one   | one    |  2.00000 |      TST | Removed |
-| two   | two    |  9.00000 |      TST | Removed |
-| three | three  | 15.00000 |      TST | Removed |
-| four  | four   | 16.00000 |      TST | Removed |
-| five  | five   | 24.00000 |      TST | Removed |
-| six   | six    | 30.00000 |      TST | Removed |
-+-------+--------+----------+----------+---------+
++-------+--------+----------+----------------+-----------------+---------+
+| Name  | Prefix | Position | Input Branches | Output Branches |   State |
++-------+--------+----------+----------------+-----------------+---------+
+| zero  | zero   |  0.00000 |        ['TST'] |         ['TST'] | Removed |
+| one   | one    |  2.00000 |        ['TST'] |         ['TST'] | Removed |
+| two   | two    |  9.00000 |        ['TST'] |         ['TST'] | Removed |
+| three | three  | 15.00000 |        ['TST'] |         ['TST'] | Removed |
+| four  | four   | 16.00000 |        ['TST'] |  ['TST', 'SIM'] | Removed |
+| five  | five   | 24.00000 |        ['TST'] |         ['TST'] | Removed |
+| six   | six    | 30.00000 |        ['TST'] |         ['TST'] | Removed |
++-------+--------+----------+----------------+-----------------+---------+
 """

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
+from setuptools import find_packages, setup
+
 import versioneer
-from setuptools import setup, find_packages
 
 with open("requirements.txt", "rt") as fp:
     install_requires = [
@@ -22,7 +23,8 @@ setup(
     entry_points={
         'console_scripts': [
             'lightpath = lightpath.__main__:entrypoint',
-        ]
+        ],
+        "happi.containers": ["lightpath = lightpath.happi.containers"],
     },
     install_requires=install_requires,
     python_requires=">=3.6",


### PR DESCRIPTION
# Still very much a work in progress

## Description
This is a doozy, but I think it's time to start writing some of this down.  

- applies the new Lightpath interface from https://github.com/pcdshub/pcdsdevices/pull/1028/ to the `BeamPath` and `BeamController` objects
- uses this interface to represent the facility as a directed graph
  - uses simple path finding algorithms to find routes to a given beamline
  - sets out methods for handling multiple paths to the same destination
- Adds and updates tests accordingly 
  - Adds a new `path.json` file that roughly reflects the current LCLS beamlines 

## Motivation and Context
Lightpath in its current incarnation cannot represent the LCLS facility.  This representation is hopefully more robust, and allows for new devices and beam paths to be added.

## How Has This Been Tested?
A best effort has been made to keep the old tests working, but new tests will be soon to come.

## Where Has This Been Documented?
This PR, to start.  We'll see how much of my brain-dump style notes make it in here.  Perhaps a confluence page is worthwhile
