### PR TITLE
ENH: find happi db from config, add sim option

### DIFF
--- a/lightpath/tests/conftest.py
+++ b/lightpath/tests/conftest.py
@@ -92,7 +92,8 @@ class Valve(Device):
                               attr='_current_destination',
                               kind=Kind.hinted)
 
-    lightpath_summary = Cpt(SummarySignal, name='lp_summary')
+    lightpath_summary = Cpt(SummarySignal, name='lp_summary',
+                            kind='omitted')
 
     lightpath_cpts = ['current_state', 'current_transmission',
                       'current_destination']


### PR DESCRIPTION
## Description
- Removes hard coded `DEVICE_CONFIG`
- loads a happi client from config by default
- adds an option to run lightpath with the sim database

## Motivation and Context
closes #134 
Also sneaks in this sim option which might be useful later

## How Has This Been Tested?
tests run locally.  interactive testing shows the database getting the right path, but currently the database is not up-to-date.

## Where Has This Been Documented?
CLI documentation updated.  