### PR TITLE
Follow-up bug fixes, gui details

### DIFF
--- a/docs/source/upcoming_release_notes/142-fix_gui_tests.rst
+++ b/docs/source/upcoming_release_notes/142-fix_gui_tests.rst
@@ -1,0 +1,26 @@
+142 fix_gui_tests
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- Add the option to specify an end-z in the beamlines config, for endstations that exist in the middle of a branch.
+
+Bugfixes
+--------
+- Fixes behavior of upstream filter checkbox by converting it to a combo box that allows users to select a device to filter devices upstream of.  This now works with the current facility representation.
+- Disables happi caching to prevent devices from persisting across tests.
+- Extends the default EpicsSignal timeout to allow devices to connect.
+
+Maintenance
+-----------
+- GUI now subscribes to lightpath_summary signals instead of the device
+- Remove unneeded call to ``lightpath_summary.get``
+- Properly unsubscribes from signals on GUI shutdown
+
+Contributors
+------------
+- tangkong

--- a/lightpath/__main__.py
+++ b/lightpath/__main__.py
@@ -36,6 +36,10 @@ def main(db, hutches):
     db: str
         Path to happi JSON database
     """
+
+    from ophyd.signal import EpicsSignalBase
+    EpicsSignalBase.set_defaults(timeout=10.0, connection_timeout=10.0)
+
     if db is None:
         client = happi.Client.from_config()
     else:

--- a/lightpath/config.py
+++ b/lightpath/config.py
@@ -2,7 +2,9 @@
 Configuration for LCLS beamlines
 """
 
-# mapping of endstation to branch name, (and possibly branch name to z end)
+# mapping of endstation to either:
+# - a list of branch names
+# - a mapping of branch names to final z position
 beamlines = {'XPP': {'L0': 800, 'L2': None},
              'XCS': ['L3'],
              'MFX': ['L5'],

--- a/lightpath/config.py
+++ b/lightpath/config.py
@@ -2,14 +2,14 @@
 Configuration for LCLS beamlines
 """
 
-# mapping of endstation to branch name
-beamlines = {'XPP': ['L0', 'L2'],
+# mapping of endstation to branch name, (and possibly branch name to z end)
+beamlines = {'XPP': {'L0': 800, 'L2': None},
              'XCS': ['L3'],
              'MFX': ['L5'],
              'CXI': ['L0'],
              'MEC': ['L4'],
              'TMO': ['K4'],
              'CRIX': ['K1'],
-             'qRIX': ['K2'],
+             'QRIX': ['K2'],
              'TXI': ['K3', 'L1']}
 sources = ['K0', 'L0']

--- a/lightpath/controller.py
+++ b/lightpath/controller.py
@@ -98,7 +98,9 @@ class LightController:
         """
         Load a beamline given the facility graph.  Finds all possible
         paths from facility sources to the endstation's branch.
-        Branches are mapped to endstations in the config
+        Branches are mapped to endstations in the config.
+        Each branch can be optionally mapped to a final z to
+        consider part of the path.
 
         Loads valid beampaths into the LightController.beamlines
         attribute for latedr access.
@@ -133,7 +135,19 @@ class LightController:
             devices = [dat['dev'] for _, dat in subgraph.nodes.data()
                        if dat['dev'] is not None]
             bp = BeamPath(*devices, name=endstation)
-            self.beamlines[endstation].append(bp)
+
+            try:
+                # access the last z for this branch
+                # end_branches is a dictionary
+                last_z = end_branches[path[-1]]
+                if last_z:
+                    # append path with all devices before last z
+                    self.beamlines[endstation].append(bp.split(last_z)[0])
+                else:
+                    self.beamlines[endstation].append(bp)
+            except TypeError:
+                # end_branches is a simple list, no splitting needed
+                self.beamlines[endstation].append(bp)
 
     @staticmethod
     def imped_z(path: BeamPath) -> float:

--- a/lightpath/controller.py
+++ b/lightpath/controller.py
@@ -141,18 +141,23 @@ class LightController:
                        if dat['dev'] is not None]
             bp = BeamPath(*devices, name=endstation)
 
-            try:
+            if isinstance(end_branches, dict):
                 # access the last z for this branch
-                # end_branches is a dictionary
+                # if end_branches is Dict[BranchName, end_z], grab last
+                # allowable z with the branch name (last node in path)
                 last_z = end_branches[path[-1]]
                 if last_z:
                     # append path with all devices before last z
                     self.beamlines[endstation].append(bp.split(last_z)[0])
                 else:
                     self.beamlines[endstation].append(bp)
-            except TypeError:
+            elif isinstance(end_branches, list):
                 # end_branches is a simple list, no splitting needed
                 self.beamlines[endstation].append(bp)
+            else:
+                raise TypeError('config is incorrectly formatted '
+                                f'(found mapping from {endstation} to '
+                                f'{type(end_branches)}).')
 
     @staticmethod
     def imped_z(path: BeamPath) -> float:

--- a/lightpath/path.py
+++ b/lightpath/path.py
@@ -550,8 +550,6 @@ class BeamPath(OphydObject):
                 try:
                     dev.lightpath_summary.subscribe(self._device_moved,
                                                     run=False)
-                    # get once to initialize SummarySignal
-                    dev.lightpath_summary.get()
                 except Exception:
                     logger.error("BeamPath is unable to subscribe "
                                  "to device %s", dev.name)

--- a/lightpath/tests/__init__.py
+++ b/lightpath/tests/__init__.py
@@ -1,2 +1,0 @@
-from .conftest import lcls_client  # noqa
-from .conftest import simulated_path as path  # noqa

--- a/lightpath/tests/__init__.py
+++ b/lightpath/tests/__init__.py
@@ -1,0 +1,2 @@
+from .conftest import lcls_client  # noqa
+from .conftest import simulated_path as path  # noqa

--- a/lightpath/tests/conftest.py
+++ b/lightpath/tests/conftest.py
@@ -197,8 +197,7 @@ def device():
 
 
 # Basic Beamline
-@pytest.fixture(scope='function')
-def path():
+def simulated_path():
     # Assemble device lists
     devices = [Valve('zero', name='zero', z=0., input_branches=['TST'],
                      output_branches=['TST']),
@@ -221,9 +220,9 @@ def path():
     return BeamPath(*devices, name='TST')
 
 
-# @pytest.fixture(scope='function')
-# def path():
-#     return simulated_path()
+@pytest.fixture(scope='function')
+def path():
+    return simulated_path()
 
 
 # Beamline that requires optic insertion

--- a/lightpath/tests/conftest.py
+++ b/lightpath/tests/conftest.py
@@ -5,8 +5,7 @@ from types import SimpleNamespace
 import happi
 import pytest
 from ophyd import Component as Cpt
-from ophyd import Device, Kind
-from ophyd.signal import AttributeSignal
+from ophyd import Device, Kind, Signal
 from ophyd.status import DeviceStatus
 from ophyd.utils import DisconnectedError
 from pcdsdevices.signal import AggregateSignal
@@ -82,14 +81,11 @@ class Valve(Device):
     _default_sub = SUB_STATE
     _icon = 'fa.adjust'
 
-    current_state = Cpt(AttributeSignal,
-                        attr='status',
+    current_state = Cpt(Signal, value=Status.removed,
                         kind=Kind.hinted)
-    current_transmission = Cpt(AttributeSignal,
-                               attr='_transmission',
+    current_transmission = Cpt(Signal, value=0.0,
                                kind=Kind.normal)
-    current_destination = Cpt(AttributeSignal,
-                              attr='_current_destination',
+    current_destination = Cpt(Signal, value='N/A',
                               kind=Kind.hinted)
 
     lightpath_summary = Cpt(SummarySignal, name='lp_summary',
@@ -105,23 +101,15 @@ class Valve(Device):
         self.md.z = z
         self.input_branches = input_branches
         self.output_branches = output_branches
-        self.status = Status.removed
+        self.current_state.put(Status.removed)
+        self.current_transmission.put(self._transmission)
+        self.current_destination.put(self.output_branches[0])
         for sig in self.lightpath_cpts:
             self.lightpath_summary.add_signal_by_attr_name(sig)
 
-    @property
-    def _current_destination(self):
-        """String returning current destination"""
-        return self.output_branches[0]
-
-    @property
-    def _current_state(self):
-        """String of state for current_state AttributeSignal"""
-        return self.status
-
     def get_lightpath_state(self):
         """Return LightpathState object"""
-        status = self.status
+        status = self.current_state.get()
         if status == Status.disconnected:
             raise DisconnectedError("Simulated Disconnection")
         inserted = status in (Status.inserted, Status.inconsistent)
@@ -178,24 +166,24 @@ class Crystal(Valve):
     _icon = 'fa.star'
     _transmission = 0.8
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    # when inserted, which branch do you take?
+    _inserted_branch = Cpt(Signal, value=1)
 
-    @property
-    def _current_destination(self):
+    def get_lightpath_state(self):
         """
         Return current beam destination
         """
-        inserted = self.status in (Status.inserted, Status.inconsistent)
-        removed = self.status in (Status.removed, Status.inconsistent)
-        if inserted:
-            return self.output_branches[1]
+        state = super().get_lightpath_state()
+        if state.inserted:
+            br = self._inserted_branch.get()
+            self.current_destination.put(self.output_branches[br])
+            state.output_branch = self.output_branches[br]
 
-        elif removed:
-            return self.output_branches[0]
+        elif state.removed:
+            self.current_destination.put(self.output_branches[0])
+            state.output_branch = self.output_branches[0]
 
-        else:
-            raise ValueError
+        return state
 
 
 ############

--- a/lightpath/tests/conftest.py
+++ b/lightpath/tests/conftest.py
@@ -287,7 +287,7 @@ def lcls():
 
 
 @pytest.fixture(scope='function')
-def lcls_client():
+def lcls_client(monkeypatch):
     db = os.path.join(os.path.dirname(__file__), 'path.json')
     print(db)
     client = happi.Client(path=db)
@@ -299,10 +299,8 @@ def lcls_client():
     def new_get(self, use_cache=True, **kwargs):
         return old_get(self, use_cache=False, **kwargs)
 
-    happi.SearchResult.get = new_get
-    yield client
-
-    happi.SearchResult.get = old_get
+    monkeypatch.setattr(happi.SearchResult, 'get', new_get)
+    return client
 
 
 @pytest.fixture(scope='function')

--- a/lightpath/tests/test_controller.py
+++ b/lightpath/tests/test_controller.py
@@ -4,8 +4,8 @@ from lightpath import LightController
 
 
 def test_controller_paths(lcls_client: happi.Client):
-    beamlines = {'XPP': 15, 'XCS': 13, 'MFX': 14, 'CXI': 15, 'MEC': 14,
-                 'TMO': 11, 'CRIX': 11, 'qRIX': 11, 'TXI': 5}
+    beamlines = {'XPP': 8, 'XCS': 13, 'MFX': 14, 'CXI': 15, 'MEC': 14,
+                 'TMO': 11, 'CRIX': 11, 'QRIX': 11, 'TXI': 5}
 
     # load controller with all beamlines + invalid ones
     controller = LightController(lcls_client,
@@ -23,19 +23,18 @@ def test_controller_paths(lcls_client: happi.Client):
     for line in ['XPP', 'XCS', 'MFX', 'CXI', 'MEC']:
         assert controller.active_path(line).path[0].name == 'im1l0'
     # all SXR lines share a beginning
-    for line in ['TMO', 'CRIX', 'qRIX']:
+    for line in ['TMO', 'CRIX', 'QRIX']:
         assert controller.active_path(line).path[0].name == 'im1k0'
     # TXI omitted, doesn't work yet
 
-    # XPP Shouldn't end here...
-    # assert controller.active_path('XPP').path[-1].name == 'XCS:LODCM'
+    assert controller.active_path('XPP').path[-1].name == 'xpp_lodcm'
     assert controller.active_path('XCS').path[-1].name == 'im2l3'
     assert controller.active_path('MFX').path[-1].name == 'im2l5'
     assert controller.active_path('CXI').path[-1].name == 'im6l0'
     assert controller.active_path('MEC').path[-1].name == 'im2l4'
     assert controller.active_path('TMO').path[-1].name == 'sl2k4'
     assert controller.active_path('CRIX').path[-1].name == 'im4k1'
-    assert controller.active_path('qRIX').path[-1].name == 'im2k2'
+    assert controller.active_path('QRIX').path[-1].name == 'im2k2'
 
 
 def test_changing_paths(lcls_ctrl: LightController):

--- a/lightpath/tests/test_gui.py
+++ b/lightpath/tests/test_gui.py
@@ -1,13 +1,20 @@
 from distutils.spawn import find_executable
 from unittest.mock import Mock
 
+import pytest
+
 from lightpath.controller import LightController
 from lightpath.ui import LightApp
 
 
-def test_app_buttons(lcls_client, qtbot):
+@pytest.fixture(scope='function')
+def lightapp(lcls_client, qtbot):
     lightapp = LightApp(LightController(lcls_client))
     qtbot.addWidget(lightapp)
+    yield lightapp
+
+
+def test_app_buttons(lightapp):
     # Create widgets
     assert len(lightapp.select_devices('MEC')) == 14
     # Setup new display
@@ -22,9 +29,7 @@ def test_lightpath_launch_script():
     assert find_executable('lightpath')
 
 
-def test_focus_on_device(lcls_client, monkeypatch, qtbot):
-    lightapp = LightApp(LightController(lcls_client))
-    qtbot.addWidget(lightapp)
+def test_focus_on_device(lightapp, monkeypatch):
     row = lightapp.rows[8][0]
     monkeypatch.setattr(lightapp.scroll,
                         'ensureWidgetVisible',
@@ -41,9 +46,7 @@ def test_focus_on_device(lcls_client, monkeypatch, qtbot):
     lightapp.focus_on_device('blah')
 
 
-def test_filtering(lcls_client, monkeypatch, qtbot):
-    lightapp = LightApp(LightController(lcls_client))
-    qtbot.addWidget(lightapp)
+def test_filtering(lightapp, monkeypatch):
     lightapp.destination_combo.setCurrentIndex(4)  # set current to MEC
     # Create mock functions
     for row in lightapp.rows:
@@ -87,16 +90,13 @@ def test_filtering(lcls_client, monkeypatch, qtbot):
             row[0].setHidden.assert_called_with(False)
 
 
-def test_typhos_display(lcls_client, qtbot):
-    lightapp = LightApp(LightController(lcls_client))
-    qtbot.addWidget(lightapp)
+def test_typhos_display(lightapp):
     # Smoke test the hide button without a detailed display
     lightapp.hide_detailed()
     assert lightapp.detail_layout.count() == 2
     assert lightapp.device_detail.isHidden()
     lightapp.show_detailed(lightapp.rows[0][0].device)
     assert lightapp.detail_layout.count() == 3
-    qtbot.addWidget(lightapp.detail_screen)
     assert not lightapp.device_detail.isHidden()
     # Smoke test the hide button without a detailed display
     lightapp.hide_detailed()

--- a/lightpath/tests/test_gui.py
+++ b/lightpath/tests/test_gui.py
@@ -30,7 +30,7 @@ def test_lightpath_launch_script():
 
 
 def test_focus_on_device(lightapp, monkeypatch):
-    row = lightapp.rows[8][0]
+    row = lightapp.rows[7][0]
     monkeypatch.setattr(lightapp.scroll,
                         'ensureWidgetVisible',
                         Mock())

--- a/lightpath/tests/test_path.py
+++ b/lightpath/tests/test_path.py
@@ -194,6 +194,16 @@ def test_callback(path: BeamPath):
     assert cb.called
 
 
+def test_summary_signal(device):
+    cb = Mock()
+
+    device.lightpath_summary.subscribe(cb, run=False)
+    device.lightpath_summary.get()
+    device.insert()
+    device.remove()
+    assert cb.called
+
+
 known_table = """\
 +-------+--------+----------+----------------+-----------------+---------+
 | Name  | Prefix | Position | Input Branches | Output Branches |   State |

--- a/lightpath/tests/test_path.py
+++ b/lightpath/tests/test_path.py
@@ -9,6 +9,10 @@ from lightpath.path import DeviceState, find_device_state
 from .conftest import Crystal, Status
 
 
+def raiser(*args, **kwargs):
+    raise ValueError
+
+
 def test_find_device_state(device: Device):
     # In
     device.insert()
@@ -17,12 +21,12 @@ def test_find_device_state(device: Device):
     device.remove()
     assert find_device_state(device)[0] == DeviceState.Removed
     # Unknown
-    device.status = Status.unknown
+    device.current_state.put(Status.unknown)
     assert find_device_state(device)[0] == DeviceState.Unknown
     # Disconnected
-    device.status = Status.disconnected
+    device.current_state.put(Status.disconnected)
     # Error
-    del device.status
+    device.get_lightpath_state = raiser
     assert find_device_state(device)[0] == DeviceState.Error
 
 
@@ -99,7 +103,7 @@ def test_single_impediment(path: BeamPath, branch: BeamPath):
     assert branch.cleared is False
 
     # Broken device
-    del path.path[0].status
+    path.path[0].get_lightpath_state = raiser
     assert find_device_state(path.path[0])[0] == DeviceState.Error
     assert path.impediment == path.path[0]
 

--- a/lightpath/tests/test_widgets.py
+++ b/lightpath/tests/test_widgets.py
@@ -20,6 +20,7 @@ def lightrow(path, qtbot):
 
 def test_widget_updates(lightrow):
     # Toggle device to trigger callbacks
+    lightrow.device.insert()
     lightrow.device.remove()
     assert (to_stylesheet_color(state_colors[0])
             in lightrow.state_label.styleSheet())

--- a/lightpath/ui/gui.py
+++ b/lightpath/ui/gui.py
@@ -263,6 +263,13 @@ class LightApp(Display):
                 for widget in row:
                     widget.update_light(_in, _out)
 
+    def _destroy_lightpath_summary_signals(self, *args, **kwargs):
+        """ Update all widgets in rows """
+        # destroy all signals
+        logger.debug('destroying all lightpath_summary signals')
+        for row in self.rows:
+            row[0].device.lightpath_summary.destroy()
+
     @pyqtSlot()
     @pyqtSlot(str)
     def focus_on_device(self, name=None):
@@ -362,3 +369,7 @@ class LightApp(Display):
         # Further resize-ing of the widget should affect the fancy slider
         super().resizeEvent(evt)
         self.resizeSlider()
+
+    def closeEvent(self, a0) -> None:
+        self._destroy_lightpath_summary_signals()
+        return super().closeEvent(a0)

--- a/lightpath/ui/lightapp.ui
+++ b/lightpath/ui/lightapp.ui
@@ -196,6 +196,32 @@
              </item>
             </layout>
            </item>
+           <item>
+            <layout class="QHBoxLayout" name="hide_upstream" stretch="0,1">
+             <property name="spacing">
+              <number>15</number>
+             </property>
+             <property name="bottomMargin">
+              <number>5</number>
+             </property>
+             <item>
+              <widget class="QLabel" name="hide_upstream_label">
+               <property name="font">
+                <font>
+                 <weight>75</weight>
+                 <bold>true</bold>
+                </font>
+               </property>
+               <property name="text">
+                <string>Hide upstream of</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QComboBox" name="upstream_device_combo"/>
+             </item>
+            </layout>
+           </item>
           </layout>
          </widget>
         </item>
@@ -210,7 +236,7 @@
           <property name="title">
            <string>Filtering Options</string>
           </property>
-          <layout class="QVBoxLayout" name="verticalLayout_2" stretch="0,0,0">
+          <layout class="QVBoxLayout" name="verticalLayout_2" stretch="0,0">
            <property name="spacing">
             <number>3</number>
            </property>
@@ -220,28 +246,6 @@
            <property name="bottomMargin">
             <number>10</number>
            </property>
-           <item>
-            <widget class="QCheckBox" name="upstream_check">
-             <property name="enabled">
-              <bool>true</bool>
-             </property>
-             <property name="font">
-              <font>
-               <weight>50</weight>
-               <bold>false</bold>
-              </font>
-             </property>
-             <property name="text">
-              <string>Show upstream devices</string>
-             </property>
-             <property name="checked">
-              <bool>true</bool>
-             </property>
-             <property name="tristate">
-              <bool>false</bool>
-             </property>
-            </widget>
-           </item>
            <item>
             <widget class="QCheckBox" name="remove_check">
              <property name="font">
@@ -340,8 +344,8 @@
           <rect>
            <x>0</x>
            <y>0</y>
-           <width>423</width>
-           <height>434</height>
+           <width>384</width>
+           <height>428</height>
           </rect>
          </property>
          <property name="sizePolicy">

--- a/lightpath/ui/widgets.py
+++ b/lightpath/ui/widgets.py
@@ -128,9 +128,11 @@ class LightRow(InactiveRow):
         # Subscribe device to state changes
         try:
             # Wait for later to update widget
-            self.device.subscribe(self._update_from_device,
-                                  event_type=self.device.SUB_STATE,
-                                  run=False)
+            logger.debug(f"Subscribing widget to device {self.device.name}")
+            self.device.lightpath_summary.subscribe(
+                self._update_from_device,
+                run=False
+            )
         except Exception:
             logger.error("Widget is unable to subscribe to device %s",
                          device.name)
@@ -138,7 +140,6 @@ class LightRow(InactiveRow):
         # Add hints for ophyd Device
         def hinted_filter(walk):
             return walk.item.kind == Kind.hinted
-
         hinted_signals = get_all_signals_from_device(device,
                                                      filter_by=hinted_filter)
         if len(hinted_signals) >= self.MAX_HINTS:


### PR DESCRIPTION
## Description
Fixes a slew of issues/errors found while running the gui on the updated happi db.  Individual problems will be documented below.
<details> <summary>Detailed problem documentation</summary>

### 1. EPICS Context unset on teardown
- **Problem**: on teardown, an immense amount of traceback initiated by EPICS CA contexts being unset.
- **Explanation**: On shutdown, nothing is done to gracefully complete/close any in-progress callbacks.  
- **Fix**: Hooked the closeEvent method to run a clean-up method that destroys all the `lightpath_summary` signals before closing.  (This might be a bit heavy handed, but it worked)

### 2. GUI subscriptions should subscribe to `lightpath_summary` signal
- **Problem**: widget subscriptions still subscribed to the whole device with SUB_STATE.  This resulted in failures of the widget to subscribe to some devices, due to SUB_STATE being missing.
- **Fix**: subscribe to `lightpath_summary` directly in the LightRow widget.  Remember to initialize the `SummarySignal` by calling `lightpath_summary.get()` after subscribing

### 2.1. Getting stuck waiting on a Lock forever while calling `lightpath_summary.get()`
- **Problem**: After changing the subscription method in LightRow, GUI initialization would hang.  
- **Explanation**: This was tracked down to an issue with locks colliding.  Signal callbacks subscribed by the GUI will run while the `lightpath_summary._lock` is claimed/locked.  These callbacks also had a chance to try and subscribe widgets to devices, which in turn called `lightpath_summary.get()` and attempted to grab `lightpath_summary._lock`.  
- ~~**easy fix**: keep track of if `lightpath_summary.get()` has been called, and only call it once~~
- **better fix**: don't call `lightpath_summary.get()` at all, since value callbacks will initialize and run callbacks on their own.  Previously we needed to do this for the test suite to run, but switching from AttributeSignal fixed this in the test suite

### 3. `get_lightpath_state` returns None
- **Problem**: occasionally a device would fail to return a `LightpathState` from `get_lightpath_state`, despite devices working in isolation
- **Fix**: Currently just sleeping after LightController creation and before LightApp creation quenches these errors.  Should probably do something more robust.

### 4. TimoutErrors, pyepics failed to send connection and access rights...
- **Problem**: many PV's fail to connect within the default 1.0s.  And with the huge number of them we can get a lot of errors
- **Fix**: Increase the default timeout settings at the `EpicsSignalBase` level

### 5. `get_lightpath_state()` returns None, and subsequent methods fail
- **Problem**: At startup, many instances of `Unable to determine device state`.  The GUI will open, with many devices in an indeterminate (purple) state.  Eventually callbacks will refresh the GUI, and the beampath will be updated.
- **Fix**: Can sleep at startup to let PV's connect and allow devices to fully initialize.  This is probably bad.   This is also not the most breaking issue, it's more annoying than anything. 

### 6. Beamlines that end in the middle of a branch
- **Problem**: #137 .  Some beamlines end in the middle of a branch, and there was no handling of this before
- **Fix**: allow the config to be a dictionary of {branch_name: `end_z`} mappings, and split paths through that branch on the given `end_z`.  

### 7. Upstream checkbox does nothing
- **Fix**: Change behavior to allow user to select a device to filter devices upstream of.  Now that devices live on branches rather than beamlines, there is no natural way to determine what a-priori a device to consider the first on the beamline.  
<img width="706" alt="image" src="https://user-images.githubusercontent.com/35379409/181630632-0b743494-1311-4035-80be-17ddc4b1f303.png">

</details>

Tests and fixtures were also touched up, notably to properly prevent devices from being cached by happi, which led to callbacks being carried over between tests.  Despite the short description this one brought me pain.

## Motivation and Context
I want to actually run the lightpath app.

## How Has This Been Tested?
test suite, and lots of interactive testing.

## Where Has This Been Documented?
This PR, for now