### PR TITLE
ENH: Make device loading lazy, make mock devices available

### DIFF
--- a/docs/source/upcoming_release_notes/145-enh_lazy_graphs.rst
+++ b/docs/source/upcoming_release_notes/145-enh_lazy_graphs.rst
@@ -1,0 +1,23 @@
+145 enh_lazy_graphs
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- defers device instantiation until needed by BeamPath objects, loading facility graph with only happi database information
+- create a mock device if device in happi cannot be created
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- moves simulated out of the test suite for reuse elsewhere
+
+Contributors
+------------
+- tangkong

--- a/lightpath/controller.py
+++ b/lightpath/controller.py
@@ -462,7 +462,8 @@ class LightController:
         graph = nx.DiGraph()
         result_list = list(branch_devs)
         result_list.sort(key=lambda x: x.metadata['z'])
-        # label nodes with device name, store ophyd device
+        # label nodes with device name, store SearchResult and leave
+        # a place for the ophyd device
         nodes = []
         for res in result_list:
             nodes.append((res.metadata['name'],
@@ -554,12 +555,7 @@ class LightController:
         Returns
         -------
         Device
-            requested device
-
-        Raises
-        ------
-        DeviceLoadingError
-            if the requested device is in the facility but cannot be loaded
+            requested device, or a mock version of the device
         """
         try:
             dev_data = self.graph.nodes[device_name]

--- a/lightpath/errors.py
+++ b/lightpath/errors.py
@@ -4,3 +4,8 @@ class CoordinateError(Exception):
 
 class PathError(Exception):
     pass
+
+
+class DeviceLoadingError(Exception):
+    """Error encountered while trying to instantiate device"""
+    pass

--- a/lightpath/errors.py
+++ b/lightpath/errors.py
@@ -4,8 +4,3 @@ class CoordinateError(Exception):
 
 class PathError(Exception):
     pass
-
-
-class DeviceLoadingError(Exception):
-    """Error encountered while trying to instantiate device"""
-    pass

--- a/lightpath/mock_devices.py
+++ b/lightpath/mock_devices.py
@@ -1,0 +1,155 @@
+from types import SimpleNamespace
+
+from ophyd import Component as Cpt
+from ophyd import Device, Kind, Signal
+from ophyd.status import DeviceStatus
+from ophyd.utils import DisconnectedError
+from pcdsdevices.signal import AggregateSignal
+
+from .path import LightpathState
+
+
+#####################
+# Simulated Classes #
+#####################
+class SummarySignal(AggregateSignal):
+    """
+    Signal that holds a hash of the values of the constituent signals.
+
+    Meant to allow tracking of constituent signals via callbacks.
+
+    The calculated readback value is useless, and should not be used
+    in any downstream calculations.  Use the signal/PV you actually
+    care about instead.
+    """
+    def _calc_readback(self):
+        values = tuple(sig.get() for sig in self._signals)
+        # We return a hash here, rather than the tuple, to always provide
+        # an ophyd-compatible datatype.
+        return hash(values)
+
+
+class Status:
+    """
+    Hold pseudo-status
+    """
+    inserted = 0
+    removed = 1
+    unknown = 2
+    inconsistent = 3
+    disconnected = 4
+
+
+class Valve(Device):
+    """
+    Basic device to facilitate in/out positioning
+    """
+    _transmission = 0.0
+    _veto = False
+    SUB_STATE = 'sub_state_changed'
+    _default_sub = SUB_STATE
+    _icon = 'fa.adjust'
+
+    current_state = Cpt(Signal, value=Status.removed,
+                        kind=Kind.hinted)
+    current_transmission = Cpt(Signal, value=0.0,
+                               kind=Kind.normal)
+    current_destination = Cpt(Signal, value='N/A',
+                              kind=Kind.hinted)
+
+    lightpath_summary = Cpt(SummarySignal, name='lp_summary',
+                            kind='omitted')
+
+    lightpath_cpts = ['current_state', 'current_transmission',
+                      'current_destination']
+
+    def __init__(self, prefix='', *, name, z, input_branches, output_branches):
+        super().__init__(name, name=name)
+        self.prefix = prefix
+        self.md = SimpleNamespace()
+        self.md.z = z
+        self.input_branches = input_branches
+        self.output_branches = output_branches
+        self.current_state.put(Status.removed)
+        self.current_transmission.put(self._transmission)
+        self.current_destination.put(self.output_branches[0])
+        for sig in self.lightpath_cpts:
+            self.lightpath_summary.add_signal_by_attr_name(sig)
+
+    def get_lightpath_state(self):
+        """Return LightpathState object"""
+        status = self.current_state.get()
+        if status == Status.disconnected:
+            raise DisconnectedError("Simulated Disconnection")
+        inserted = status in (Status.inserted, Status.inconsistent)
+        removed = status in (Status.removed, Status.inconsistent)
+        return LightpathState(
+            inserted=inserted, removed=removed,
+            transmission=self.current_transmission.get(),
+            output_branch=self.current_destination.get()
+        )
+
+    def insert(self, timeout=None, finished_cb=None):
+        """
+        Insert the device into the beampath
+        """
+        # Complete request s.t. callbacks run
+        self.current_state.put(Status.inserted)
+        # Return complete status object
+        status = DeviceStatus(self)
+        status.set_finished()
+        return status
+
+    def remove(self, wait=False, timeout=None, finished_cb=None):
+        """
+        Remove the device from the beampath
+        """
+        # Complete request
+        self.current_state.put(Status.removed)
+        # Return complete status object
+        status = DeviceStatus(self)
+        status.set_finished()
+        return status
+
+
+class IPIMB(Valve):
+    """
+    Generic Passive Device
+    """
+    _transmission = 0.6
+    _icon = 'fa.th-large'
+
+
+class Stopper(Valve):
+    """
+    Generic Veto Device
+    """
+    _veto = True
+    _icon = 'fa.times-circle'
+
+
+class Crystal(Valve):
+    """
+    Generic branching device
+    """
+    _icon = 'fa.star'
+    _transmission = 0.8
+
+    # when inserted, which branch do you take?
+    _inserted_branch = Cpt(Signal, value=1)
+
+    def get_lightpath_state(self):
+        """
+        Return current beam destination
+        """
+        state = super().get_lightpath_state()
+        if state.inserted:
+            br = self._inserted_branch.get()
+            self.current_destination.put(self.output_branches[br])
+            state.output_branch = self.output_branches[br]
+
+        elif state.removed:
+            self.current_destination.put(self.output_branches[0])
+            state.output_branch = self.output_branches[0]
+
+        return state

--- a/lightpath/tests/conftest.py
+++ b/lightpath/tests/conftest.py
@@ -1,17 +1,12 @@
 import logging
 import os.path
-from types import SimpleNamespace
 
 import happi
 import pytest
-from ophyd import Component as Cpt
-from ophyd import Device, Kind, Signal
-from ophyd.status import DeviceStatus
-from ophyd.utils import DisconnectedError
-from pcdsdevices.signal import AggregateSignal
 
-from lightpath import BeamPath, LightpathState
+from lightpath import BeamPath
 from lightpath.controller import LightController
+from lightpath.mock_devices import IPIMB, Crystal, Stopper, Valve
 
 
 #################
@@ -38,152 +33,6 @@ def set_level(pytestconfig):
     # Create basic configuration
     logging.basicConfig(level=log_level,
                         filename=pytestconfig.getoption('--logfile'))
-
-
-#####################
-# Simulated Classes #
-#####################
-class SummarySignal(AggregateSignal):
-    """
-    Signal that holds a hash of the values of the constituent signals.
-
-    Meant to allow tracking of constituent signals via callbacks.
-
-    The calculated readback value is useless, and should not be used
-    in any downstream calculations.  Use the signal/PV you actually
-    care about instead.
-    """
-    def _calc_readback(self):
-        values = tuple(sig.get() for sig in self._signals)
-        # We return a hash here, rather than the tuple, to always provide
-        # an ophyd-compatible datatype.
-        return hash(values)
-
-
-class Status:
-    """
-    Hold pseudo-status
-    """
-    inserted = 0
-    removed = 1
-    unknown = 2
-    inconsistent = 3
-    disconnected = 4
-
-
-class Valve(Device):
-    """
-    Basic device to facilitate in/out positioning
-    """
-    _transmission = 0.0
-    _veto = False
-    SUB_STATE = 'sub_state_changed'
-    _default_sub = SUB_STATE
-    _icon = 'fa.adjust'
-
-    current_state = Cpt(Signal, value=Status.removed,
-                        kind=Kind.hinted)
-    current_transmission = Cpt(Signal, value=0.0,
-                               kind=Kind.normal)
-    current_destination = Cpt(Signal, value='N/A',
-                              kind=Kind.hinted)
-
-    lightpath_summary = Cpt(SummarySignal, name='lp_summary',
-                            kind='omitted')
-
-    lightpath_cpts = ['current_state', 'current_transmission',
-                      'current_destination']
-
-    def __init__(self, prefix='', *, name, z, input_branches, output_branches):
-        super().__init__(name, name=name)
-        self.prefix = prefix
-        self.md = SimpleNamespace()
-        self.md.z = z
-        self.input_branches = input_branches
-        self.output_branches = output_branches
-        self.current_state.put(Status.removed)
-        self.current_transmission.put(self._transmission)
-        self.current_destination.put(self.output_branches[0])
-        for sig in self.lightpath_cpts:
-            self.lightpath_summary.add_signal_by_attr_name(sig)
-
-    def get_lightpath_state(self):
-        """Return LightpathState object"""
-        status = self.current_state.get()
-        if status == Status.disconnected:
-            raise DisconnectedError("Simulated Disconnection")
-        inserted = status in (Status.inserted, Status.inconsistent)
-        removed = status in (Status.removed, Status.inconsistent)
-        return LightpathState(
-            inserted=inserted, removed=removed,
-            transmission=self.current_transmission.get(),
-            output_branch=self.current_destination.get()
-        )
-
-    def insert(self, timeout=None, finished_cb=None):
-        """
-        Insert the device into the beampath
-        """
-        # Complete request s.t. callbacks run
-        self.current_state.put(Status.inserted)
-        # Return complete status object
-        status = DeviceStatus(self)
-        status.set_finished()
-        return status
-
-    def remove(self, wait=False, timeout=None, finished_cb=None):
-        """
-        Remove the device from the beampath
-        """
-        # Complete request
-        self.current_state.put(Status.removed)
-        # Return complete status object
-        status = DeviceStatus(self)
-        status.set_finished()
-        return status
-
-
-class IPIMB(Valve):
-    """
-    Generic Passive Device
-    """
-    _transmission = 0.6
-    _icon = 'fa.th-large'
-
-
-class Stopper(Valve):
-    """
-    Generic Veto Device
-    """
-    _veto = True
-    _icon = 'fa.times-circle'
-
-
-class Crystal(Valve):
-    """
-    Generic branching device
-    """
-    _icon = 'fa.star'
-    _transmission = 0.8
-
-    # when inserted, which branch do you take?
-    _inserted_branch = Cpt(Signal, value=1)
-
-    def get_lightpath_state(self):
-        """
-        Return current beam destination
-        """
-        state = super().get_lightpath_state()
-        if state.inserted:
-            br = self._inserted_branch.get()
-            self.current_destination.put(self.output_branches[br])
-            state.output_branch = self.output_branches[br]
-
-        elif state.removed:
-            self.current_destination.put(self.output_branches[0])
-            state.output_branch = self.output_branches[0]
-
-        return state
 
 
 ############

--- a/lightpath/tests/path.json
+++ b/lightpath/tests/path.json
@@ -186,7 +186,7 @@
         "active": true,
         "args": ["{{prefix}}"],
         "creation": "Wed Jun 22 09:53:24 2022",
-        "device_class": "pcdsdevices.pim.XPIM",
+        "device_class": "lightpath.tests.conftest.IPIMB",
         "documentation": null,
         "input_branches": [
             "K4"

--- a/lightpath/tests/test_controller.py
+++ b/lightpath/tests/test_controller.py
@@ -121,7 +121,7 @@ def test_walk_facility(lcls_ctrl: LightController):
 
 def test_mock_device(lcls_ctrl: LightController):
     # break some metadata
-    lcls_ctrl.graph.nodes['sl1k2']['res'].metadata['device_class'] = ''
+    lcls_ctrl.graph.nodes['sl1k2']['md'].res.metadata['device_class'] = ''
 
     # smoke test device loading
     lcls_ctrl.get_device('sl1k2')

--- a/lightpath/tests/test_controller.py
+++ b/lightpath/tests/test_controller.py
@@ -117,3 +117,11 @@ def test_walk_facility(lcls_ctrl: LightController):
     incidents = [d.name for d in lcls_ctrl.incident_devices]
     assert set(incidents) == set(['mr1l0', 'mr1k1'])
     assert len(lcls_ctrl.destinations) == 0
+
+
+def test_mock_device(lcls_ctrl: LightController):
+    # break some metadata
+    lcls_ctrl.graph.nodes['sl1k2']['res'].metadata['device_class'] = ''
+
+    # smoke test device loading
+    lcls_ctrl.get_device('sl1k2')

--- a/lightpath/tests/test_controller.py
+++ b/lightpath/tests/test_controller.py
@@ -5,7 +5,7 @@ from lightpath import LightController
 
 def test_controller_paths(lcls_client: happi.Client):
     beamlines = {'XPP': 8, 'XCS': 13, 'MFX': 14, 'CXI': 15, 'MEC': 14,
-                 'TMO': 11, 'CRIX': 11, 'QRIX': 11, 'TXI': 5}
+                 'TMO': 12, 'CRIX': 11, 'QRIX': 11, 'TXI': 5}
 
     # load controller with all beamlines + invalid ones
     controller = LightController(lcls_client,
@@ -38,17 +38,15 @@ def test_controller_paths(lcls_client: happi.Client):
 
 
 def test_changing_paths(lcls_ctrl: LightController):
-    assert len(lcls_ctrl.active_path('XCS').path) == 13
     assert lcls_ctrl.active_path('XCS').path[-1].name == 'im2l3'
-    assert lcls_ctrl.active_path('XCS').path[-2].name == 'xcs_lodcm'
+    assert lcls_ctrl.active_path('XCS').path[-3].name == 'mr1l4'
     assert (['mr1l4', 'xcs_lodcm', 'im5l0', 'sl4l0', 'im6l0'] ==
             lcls_ctrl.walk_facility()['source_L0'][-5:])
 
     # insert mirror to take L3 path
     lcls_ctrl.get_device('mr1l3').insert()
-    assert len(lcls_ctrl.active_path('XCS').path) == 12
     assert lcls_ctrl.active_path('XCS').path[-1].name == 'im2l3'
-    assert lcls_ctrl.active_path('XCS').path[-2].name == 'sl1l3'
+    assert lcls_ctrl.active_path('XCS').path[-3].name == 'im1l3'
     assert (['xpp_lodcm', 'mr1l3', 'im1l3', 'sl1l3', 'im2l3'] ==
             lcls_ctrl.walk_facility()['source_L0'][-5:])
 

--- a/lightpath/tests/test_gui.py
+++ b/lightpath/tests/test_gui.py
@@ -47,12 +47,12 @@ def test_focus_on_device(lightapp, monkeypatch):
 
 
 def test_upstream_check(lightapp, monkeypatch):
-    assert len(lightapp.select_devices('TMO')) == 11
+    assert len(lightapp.select_devices('TMO')) == 12
 
     tmo_idx = lightapp.destination_combo.findText('TMO')
     lightapp.destination_combo.setCurrentIndex(tmo_idx)
     lightapp.change_path_display()
-    assert len(lightapp.rows) == 11
+    assert len(lightapp.rows) == 12
 
     # Create mock functions
     for row in lightapp.rows:

--- a/lightpath/tests/test_path.py
+++ b/lightpath/tests/test_path.py
@@ -4,9 +4,8 @@ from unittest.mock import Mock
 from ophyd.device import Device
 
 from lightpath import BeamPath
+from lightpath.mock_devices import Crystal, Status
 from lightpath.path import DeviceState, find_device_state
-
-from .conftest import Crystal, Status
 
 
 def raiser(*args, **kwargs):


### PR DESCRIPTION
## Description
- Make the facility graph use only database information
- Defer device instantiation until needed (when making BeamPath objects, looking for beam destinations etc)
- Attempt to make a mock device if device instantiation fails initially
  - Move simulated devices from test suite into separate module for package-wide use

## Motivation and Context
#143 
#139 part 2.

## How Has This Been Tested?
Test Suite runs, extra smoke test for mocked devices added. 

## Where Has This Been Documented?
This PR