### PR TITLE
FIX: clear subscriptions properly

### DIFF
--- a/lightpath/path.py
+++ b/lightpath/path.py
@@ -556,6 +556,17 @@ class BeamPath(OphydObject):
             self._has_subscribed = True
         super().subscribe(cb, event_type=event_type, run=run)
 
+    def clear_device_subs(self) -> None:
+        """
+        Clears the ._device_moved callbacks from all devices in the path.
+        Distinct from BeamPath.clear_sub, which unsubscribes a specific
+        callback from the BeamPath object itself.
+        """
+        if self._has_subscribed:
+            for dev in self.devices:
+                dev.lightpath_summary.clear_sub(self._device_moved)
+            self._has_subscribed = False
+
     def _repr_info(self):
         yield('range',   self.range)
         yield('devices', len(self.devices))

--- a/lightpath/ui/gui.py
+++ b/lightpath/ui/gui.py
@@ -183,12 +183,11 @@ class LightApp(Display):
             logger.debug("Resorting beampath display ...")
             # Remove old detailed screen
             self.hide_detailed()
-            # Grab all the light rows
-            rows = [self.load_device_row(d)
-                    for d in self.select_devices(self.selected_beamline())]
+
             # Clear layout if previously loaded rows exist
             if self.rows:
                 # Clear our subscribtions
+                logger.debug('clear existing subscriptions')
                 for row in self.rows:
                     # Remove from layout
                     self.lightLayout.removeWidget(row[0])
@@ -207,7 +206,12 @@ class LightApp(Display):
             for box in boxes:
                 if isinstance(box, QCheckBox):
                     box.setChecked(True)
+
+            # Grab all the light rows
+            rows = [self.load_device_row(d)
+                    for d in self.select_devices(self.selected_beamline())]
             # Add all the widgets to the display
+            logger.debug('Add widgets to display')
             for i, row in enumerate(rows):
                 # Cache row to later clear subscriptions
                 self.rows.append(row)
@@ -277,6 +281,7 @@ class LightApp(Display):
         logger.debug('destroying all lightpath_summary signals')
         for row in self.rows:
             row[0].device.lightpath_summary.destroy()
+            row[1].device.lightpath_summary.destroy()
 
     @pyqtSlot()
     @pyqtSlot(str)

--- a/lightpath/ui/gui.py
+++ b/lightpath/ui/gui.py
@@ -333,9 +333,10 @@ class LightApp(Display):
 
     def clear_subs(self):
         """
-        Clear the subscription event
+        Clear BeamPath-related subscription events
         """
         self.path.clear_sub(self.update_path)
+        self.path.clear_device_subs()
 
     @pyqtSlot()
     def show_detailed(self, device):

--- a/lightpath/ui/widgets.py
+++ b/lightpath/ui/widgets.py
@@ -211,7 +211,7 @@ class LightRow(InactiveRow):
         """
         Clear the subscription event
         """
-        self.device.clear_sub(self.update_state)
+        self.device.lightpath_summary.clear_sub(self._update_from_device)
 
 
 class DeviceWidget(QLabel):


### PR DESCRIPTION
## Description
Admittedly a bunch of bug fixes that should have been caught when we changed the subscription schema
- Properly unsubscribes callbacks from the `lightpath_summary` signal, instead of the `BeamPath` object.  
- destroy the lightpath_summary signals in all the widgets, not just the first half
- Creates `LightApp.clear_device_subs()` to unsub `BeamPath._device_moved()` all devices in a BeamPath.

## Motivation and Context
This fixes a bug but I went down too many rabbit holes and forgot to document fully with screenshots.  It definitely helps with subscriptions cleanly though.

## How Has This Been Tested?
Interactively

## Where Has This Been Documented?
This PR