### PR TITLE
BUG: Stop GUI from opening twice from `ligthpath` command

### DIFF
--- a/lightpath/__main__.py
+++ b/lightpath/__main__.py
@@ -1,3 +1,4 @@
 from .main import entrypoint
 
-entrypoint()
+if __name__ == '__main__':
+    entrypoint()

--- a/lightpath/ui/gui.py
+++ b/lightpath/ui/gui.py
@@ -11,6 +11,7 @@ import pcdsdevices.device_types as dtypes
 import typhos
 from pcdsdevices.attenuator import AttBase
 from pcdsdevices.ipm import IPMMotion
+from pcdsdevices.mirror import KBOMirror, XOffsetMirror
 from pcdsdevices.valve import PPSStopper
 from pydm import Display
 from qtpy.QtCore import Qt
@@ -46,10 +47,12 @@ class LightApp(Display):
 
     parent : optional
     """
-    shown_types = [AttBase, dtypes.GateValve, IPMMotion,
-                   dtypes.LODCM, dtypes.OffsetMirror, dtypes.PIM, PPSStopper,
-                   dtypes.PulsePicker, dtypes.Slits, dtypes.Stopper,
-                   dtypes.XFLS]
+    shown_types = {'Attenuator': AttBase, 'Gate Valve': dtypes.GateValve,
+                   'IPM': IPMMotion, 'LODCM': dtypes.LODCM,
+                   'KBOMirror': KBOMirror, 'OffsetMirror': XOffsetMirror,
+                   'PIM': dtypes.PIM, 'PPSStopper': PPSStopper,
+                   'PulsePicker': dtypes.PulsePicker, 'Slit': dtypes.Slits,
+                   'Stopper': dtypes.Stopper, 'XFLS': dtypes.XFLS}
 
     def __init__(self, controller, beamline=None,
                  parent=None, dark=True):
@@ -100,15 +103,15 @@ class LightApp(Display):
         self.destination_combo.setCurrentIndex(idx)
         # Add all of our device type options
         max_columns = 3
-        for i, row in enumerate(np.array_split(self.shown_types,
+        for i, row in enumerate(np.array_split(list(self.shown_types.items()),
                                                max_columns)):
             for j, device_type in enumerate(row):
                 # Add box to layout
-                box = QCheckBox(device_type.__name__)
+                box = QCheckBox(device_type[0])
                 box.setChecked(True)
                 self.device_types.layout().addWidget(box, j, i)
                 # Hook up box to hide function
-                self.device_buttons[box] = device_type
+                self.device_buttons[box] = device_type[1]
                 box.toggled.connect(self.filter)
         # Setup the UI
         self.change_path_display()

--- a/lightpath/ui/gui.py
+++ b/lightpath/ui/gui.py
@@ -9,6 +9,8 @@ from functools import partial
 import numpy as np
 import pcdsdevices.device_types as dtypes
 import typhos
+from pcdsdevices.attenuator import AttBase
+from pcdsdevices.ipm import IPMMotion
 from pcdsdevices.valve import PPSStopper
 from pydm import Display
 from qtpy.QtCore import Qt
@@ -44,7 +46,7 @@ class LightApp(Display):
 
     parent : optional
     """
-    shown_types = [dtypes.Attenuator, dtypes.GateValve, dtypes.IPM,
+    shown_types = [AttBase, dtypes.GateValve, IPMMotion,
                    dtypes.LODCM, dtypes.OffsetMirror, dtypes.PIM, PPSStopper,
                    dtypes.PulsePicker, dtypes.Slits, dtypes.Stopper,
                    dtypes.XFLS]
@@ -317,7 +319,8 @@ class LightApp(Display):
         for row in self.rows:
             device = row[0].device
             # Hide if a hidden instance of a device type
-            hidden_device_type = type(device) in self.hidden_devices
+            hidden_device_type = any([isinstance(device, dtype)
+                                      for dtype in self.hidden_devices])
             # Hide if removed
             hidden_removed = (not self.remove_check.isChecked()
                               and row[0].last_state == DeviceState.Removed)

--- a/lightpath/ui/gui.py
+++ b/lightpath/ui/gui.py
@@ -115,6 +115,8 @@ class LightApp(Display):
         if dark:
             typhos.use_stylesheet(dark=True)
 
+        self.setWindowTitle('Lightpath')
+
     def destinations(self):
         """
         All possible beamline destinations sorted by end point


### PR DESCRIPTION
## Description
Only run `entrypoint` once when running the `lightpath` command from the cli entrypoint. 

This is a workaround, honestly.  I'm ok with this not being merged until we figure out exactly what's going on, maybe this is just a me problem


## Motivation and Context
GUI was opening twice when running the command `lightpath` from the cli. 

For my own understanding:
* The `python -m` option runs the `__main__.py` file
  * This only runs `entrypoint()` once, as desired.
* The entrypoint `'console_scripts': ['lightpath = lightpath.main:entrypoint']` imports and runs `lightpath.main.entrypoint`.
  * For some reason this imports `__main__.py` before running `entrypoint`, which by all means it shouldn't.... 
  * I can't figure out why this is the case, and the structure of our entrypoint matches our other packages.  Those other packages don't run `__main__.py` when using the cli entrypoint.

``` console
(pcds-5.4.2)roberttk@psbuild-rhel7-01:~$ lightpath --sim
running file __main__.py, with name: lightpath.__main__
running file main.py, with name: lightpath.main
entrypoint
[2022-08-15 11:16:58] - INFO -  Launching LCLS Lightpath ...
<... clip ...>
entrypoint
[2022-08-15 11:17:10] - INFO -  Launching LCLS Lightpath ...
(pcds-5.4.2)roberttk@psbuild-rhel7-01:~$ python -m lightpath --sim
running file __main__.py, with name: __main__
running file main.py, with name: lightpath.main
entrypoint
[2022-08-15 11:17:24] - INFO -  Launching LCLS Lightpath ...
<... clip ...>
(pcds-5.4.2)roberttk@psbuild-rhel7-01:~$ 
```


## How Has This Been Tested?
Interactively.  Both `lightpath` and `python -m lightpath` work

## Where Has This Been Documented?
This PR