### PR TITLE
GUI: More expressive widget icon colors, and more along the way

### DIFF
--- a/docs/source/upcoming_release_notes/150-gui_icons_and_more.rst
+++ b/docs/source/upcoming_release_notes/150-gui_icons_and_more.rst
@@ -1,0 +1,28 @@
+150 gui_icons_and_more
+######################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- sets title of window based on current path
+- dynamically populates device_type filters with module names of devices currently in path
+- adds cumulative transmission along path as a blocking criteria
+- updates device icon color logic to consider both device and path state
+
+Bugfixes
+--------
+- removes endstation sorting to allow lazy BeamPath loading
+- fixes various font-awesome deprecation warnings
+
+Maintenance
+-----------
+- make the simulated lcls facility import-able
+- adds tests for cumulative transmission and updated icon coloring
+- make test_show_devices use regex instead of hard-coded output
+
+Contributors
+------------
+- tangkong

--- a/lightpath/mock_devices.py
+++ b/lightpath/mock_devices.py
@@ -48,7 +48,7 @@ class Valve(Device):
     _veto = False
     SUB_STATE = 'sub_state_changed'
     _default_sub = SUB_STATE
-    _icon = 'fa5.adjust'
+    _icon = 'fa.adjust'
 
     current_state = Cpt(Signal, value=Status.removed,
                         kind=Kind.hinted)

--- a/lightpath/mock_devices.py
+++ b/lightpath/mock_devices.py
@@ -116,7 +116,7 @@ class IPIMB(Valve):
     """
     Generic Passive Device
     """
-    _transmission = 0.6
+    _transmission = 0.5
     _icon = 'fa5s.th-large'
 
 

--- a/lightpath/mock_devices.py
+++ b/lightpath/mock_devices.py
@@ -40,7 +40,7 @@ class Status:
     disconnected = 4
 
 
-class Valve(Device):
+class BaseValve(Device):
     """
     Basic device to facilitate in/out positioning
     """
@@ -112,7 +112,12 @@ class Valve(Device):
         return status
 
 
-class IPIMB(Valve):
+class Valve(BaseValve):
+    """ subclass to differentiate from other mock devices """
+    pass
+
+
+class IPIMB(BaseValve):
     """
     Generic Passive Device
     """
@@ -120,7 +125,7 @@ class IPIMB(Valve):
     _icon = 'fa5s.th-large'
 
 
-class Stopper(Valve):
+class Stopper(BaseValve):
     """
     Generic Veto Device
     """
@@ -128,7 +133,7 @@ class Stopper(Valve):
     _icon = 'fa5.times-circle'
 
 
-class Crystal(Valve):
+class Crystal(BaseValve):
     """
     Generic branching device
     """

--- a/lightpath/mock_devices.py
+++ b/lightpath/mock_devices.py
@@ -48,7 +48,7 @@ class BaseValve(Device):
     _veto = False
     SUB_STATE = 'sub_state_changed'
     _default_sub = SUB_STATE
-    _icon = 'fa.adjust'
+    _icon = 'fa5s.adjust'
 
     current_state = Cpt(Signal, value=Status.removed,
                         kind=Kind.hinted)

--- a/lightpath/mock_devices.py
+++ b/lightpath/mock_devices.py
@@ -48,7 +48,7 @@ class Valve(Device):
     _veto = False
     SUB_STATE = 'sub_state_changed'
     _default_sub = SUB_STATE
-    _icon = 'fa.adjust'
+    _icon = 'fa5.adjust'
 
     current_state = Cpt(Signal, value=Status.removed,
                         kind=Kind.hinted)
@@ -117,7 +117,7 @@ class IPIMB(Valve):
     Generic Passive Device
     """
     _transmission = 0.6
-    _icon = 'fa.th-large'
+    _icon = 'fa5s.th-large'
 
 
 class Stopper(Valve):
@@ -125,14 +125,14 @@ class Stopper(Valve):
     Generic Veto Device
     """
     _veto = True
-    _icon = 'fa.times-circle'
+    _icon = 'fa5.times-circle'
 
 
 class Crystal(Valve):
     """
     Generic branching device
     """
-    _icon = 'fa.star'
+    _icon = 'fa5.star'
     _transmission = 0.8
 
     # when inserted, which branch do you take?

--- a/lightpath/path.py
+++ b/lightpath/path.py
@@ -236,12 +236,11 @@ class BeamPath(OphydObject):
                 block.append(prev_device)
             # check inserted
             elif curr_state is DeviceState.Inserted:
-                current_transmission *= curr_status.transmission
-                # Blocking if single device has low enough transmssion
-                if curr_status.transmission < self.minimum_transmission:
-                    block.append(device)
+                if curr_status.transmission > 1:
+                    logger.error(f'{device.name} reports transmission > 1')
+                current_transmission *= min(curr_status.transmission, 1)
                 # Any device seeing current transmission below min would block
-                elif current_transmission < self.minimum_transmission:
+                if current_transmission < self.minimum_transmission:
                     block.append(device)
             # Do not add device to blocking list, it is removed
             elif curr_state is DeviceState.Removed:

--- a/lightpath/tests/__init__.py
+++ b/lightpath/tests/__init__.py
@@ -1,2 +1,3 @@
 from .conftest import lcls_client  # noqa
+from .conftest import simulated_lcls as lcls  # noqa
 from .conftest import simulated_path as path  # noqa

--- a/lightpath/tests/conftest.py
+++ b/lightpath/tests/conftest.py
@@ -152,6 +152,14 @@ def lcls_client(monkeypatch):
     return client
 
 
+def simulated_lcls():
+    """ LightController with simulated lcls facility for testing """
+    db = os.path.join(os.path.dirname(__file__), 'path.json')
+    client = happi.Client(path=db)
+
+    return LightController(client)
+
+
 @pytest.fixture(scope='function')
 def lcls_ctrl(lcls_client: happi.Client):
     print(f'first item: {lcls_client.search()[0]}')

--- a/lightpath/tests/conftest.py
+++ b/lightpath/tests/conftest.py
@@ -60,7 +60,15 @@ def simulated_path():
                        output_branches=['TST', 'SIM']),
                IPIMB('five', name='five', z=24., input_branches=['TST'],
                      output_branches=['TST']),
-               Valve('six', name='six', z=30., input_branches=['TST'],
+               IPIMB('six', name='six', z=24.2, input_branches=['TST'],
+                     output_branches=['TST']),
+               IPIMB('seven', name='seven', z=24.4, input_branches=['TST'],
+                     output_branches=['TST']),
+               IPIMB('eight', name='eight', z=24.6, input_branches=['TST'],
+                     output_branches=['TST']),
+               IPIMB('nine', name='nine', z=24.8, input_branches=['TST'],
+                     output_branches=['TST']),
+               Valve('ten', name='ten', z=30., input_branches=['TST'],
                      output_branches=['TST'])
                ]
     # Create semi-random order

--- a/lightpath/tests/test_gui.py
+++ b/lightpath/tests/test_gui.py
@@ -14,7 +14,7 @@ def lightapp(lcls_client, qtbot):
     yield lightapp
 
 
-def test_app_buttons(lightapp):
+def test_app_buttons(lightapp: LightApp):
     # Create widgets
     assert len(lightapp.select_devices('MEC')) == 14
     # Setup new display
@@ -29,7 +29,7 @@ def test_lightpath_launch_script():
     assert find_executable('lightpath')
 
 
-def test_focus_on_device(lightapp, monkeypatch):
+def test_focus_on_device(lightapp: LightApp, monkeypatch):
     row = lightapp.rows[7][0]
     monkeypatch.setattr(lightapp.scroll,
                         'ensureWidgetVisible',
@@ -46,7 +46,7 @@ def test_focus_on_device(lightapp, monkeypatch):
     lightapp.focus_on_device('blah')
 
 
-def test_upstream_check(lightapp, monkeypatch):
+def test_upstream_check(lightapp: LightApp, monkeypatch):
     assert len(lightapp.select_devices('TMO')) == 12
 
     tmo_idx = lightapp.destination_combo.findText('TMO')
@@ -68,7 +68,7 @@ def test_upstream_check(lightapp, monkeypatch):
             row[0].setHidden.assert_called_with(False)
 
 
-def test_filtering(lightapp, monkeypatch):
+def test_filtering(lightapp: LightApp, monkeypatch):
     lightapp.destination_combo.setCurrentIndex(4)  # set current to MEC
     # Create mock functions
     for row in lightapp.rows:
@@ -110,7 +110,7 @@ def test_filtering(lightapp, monkeypatch):
             row[0].setHidden.assert_called_with(False)
 
 
-def test_typhos_display(lightapp):
+def test_typhos_display(lightapp: LightApp):
     # Smoke test the hide button without a detailed display
     lightapp.hide_detailed()
     assert lightapp.detail_layout.count() == 2

--- a/lightpath/tests/test_path.py
+++ b/lightpath/tests/test_path.py
@@ -137,7 +137,8 @@ def test_ignore(path: BeamPath):
 
     # Ignore passive devices in addition
     target, ignore = path._ignore(path.path[3], passive=False)
-    assert ignore == [path.path[5], path.path[4], path.path[3]]
+    assert all([dev in ignore for
+                dev in [path.path[5], path.path[4], path.path[3]]])
     assert path.path[3] not in target
     assert path.path[5] not in target
 
@@ -193,7 +194,30 @@ def test_callback(path: BeamPath):
     assert cb.called
 
 
-def test_summary_signal(device):
+def test_attenuation(path: BeamPath):
+    assert path.impediment is None
+
+    # insert imagers to attenuate 0.5 per --> 4 needed to drop below 0.1
+    for i in [5, 6, 7, 8, 9]:
+        path.path[i].insert()
+
+    assert path.impediment == path.path[8]
+    assert path.blocking_devices == [path.path[8], path.path[9]]
+
+    path.path[8].remove()
+    assert path.impediment == path.path[9]
+    assert path.blocking_devices == [path.path[9]]
+
+    path.path[8].insert()
+    path.path[5].remove()
+    assert path.impediment == path.path[9]
+    assert path.blocking_devices == [path.path[9]]
+
+    path.path[9].remove()
+    assert path.impediment is None
+
+
+def test_summary_signal(device: Device):
     cb = Mock()
 
     device.lightpath_summary.subscribe(cb, run=False)

--- a/lightpath/tests/test_widgets.py
+++ b/lightpath/tests/test_widgets.py
@@ -3,46 +3,54 @@ from unittest.mock import Mock
 import pytest
 from ophyd import Device
 
-import lightpath.ui
+from lightpath import BeamPath
+from lightpath.ui import LightRow
 from lightpath.ui.widgets import (state_colors, symbol_for_device,
                                   to_stylesheet_color)
 
 
 @pytest.fixture(scope='function')
-def lightrow(path, qtbot):
+def lightrow(path: BeamPath, qtbot):
     # Generate lightpath
-    w = lightpath.ui.LightRow(path.path[3])
+    w = LightRow(path.path[3], path)
     qtbot.addWidget(w)
     # Replace Update functions with mocks
     setattr(w.state_label, 'setText', Mock())
     return w
 
 
-def test_widget_updates(lightrow):
+def test_widget_updates(lightrow: LightRow, path: BeamPath):
+    # inserted device may still permit beam
+    ipimb = path.path[5]
+    ipimb_row = LightRow(ipimb, path)
+    ipimb.insert()
+    assert (to_stylesheet_color(state_colors['half_removed'])
+            in ipimb_row.state_label.styleSheet())
+
     # Toggle device to trigger callbacks
     lightrow.device.insert()
     lightrow.device.remove()
-    assert (to_stylesheet_color(state_colors[0])
+    assert (to_stylesheet_color(state_colors['removed'])
             in lightrow.state_label.styleSheet())
     lightrow.device.insert()
-    assert (to_stylesheet_color(state_colors[1])
+    assert (to_stylesheet_color(state_colors['blocking'])
             in lightrow.state_label.styleSheet())
     # Check that callbacks have been called
     assert lightrow.state_label.setText.called
 
 
-def test_widget_icon(lightrow):
+def test_widget_icon(lightrow: LightRow):
     assert symbol_for_device(lightrow.device) == lightrow.device._icon
     # Smoke test a device without an icon
     device = Device(name='test')
     symbol_for_device(device)
     # Smoke test a device with a malformed icon
     device._icon = 'definetly not an icon'
-    lr = lightpath.ui.LightRow(device)
+    lr = LightRow(device, lightrow.path)
     lr.update_state()
 
 
-def test_widget_hints(lightrow):
+def test_widget_hints(lightrow: LightRow):
     hint_count = len(lightrow.device.hints['fields'])
     # Check for label and control for each hint plus spacer
     assert lightrow.command_layout.count() == 2 * hint_count + 1

--- a/lightpath/ui/gui.py
+++ b/lightpath/ui/gui.py
@@ -217,12 +217,6 @@ class LightApp(Display):
                 self.rows.clear()
                 self.device_combo.clear()
                 self.upstream_device_combo.clear()
-            # # Hide nothing when switching beamlines
-            # boxes = self.device_types.children()
-            # boxes.extend([self.remove_check])
-            # for box in boxes:
-            #     if isinstance(box, QCheckBox):
-            #         box.setChecked(True)
 
             # Grab all the light rows (self.path set here)
             rows = [self.load_device_row(d)

--- a/lightpath/ui/gui.py
+++ b/lightpath/ui/gui.py
@@ -11,6 +11,7 @@ import pcdsdevices.device_types as dtypes
 import typhos
 from pcdsdevices.attenuator import AttBase
 from pcdsdevices.ipm import IPMMotion
+from pcdsdevices.mirror import KBOMirror, XOffsetMirror
 from pcdsdevices.valve import PPSStopper
 from pydm import Display
 from qtpy.QtCore import Qt
@@ -46,10 +47,12 @@ class LightApp(Display):
 
     parent : optional
     """
-    shown_types = [AttBase, dtypes.GateValve, IPMMotion,
-                   dtypes.LODCM, dtypes.OffsetMirror, dtypes.PIM, PPSStopper,
-                   dtypes.PulsePicker, dtypes.Slits, dtypes.Stopper,
-                   dtypes.XFLS]
+    shown_types = {'Attenuator': AttBase, 'Gate Valve': dtypes.GateValve,
+                   'IPM': IPMMotion, 'LODCM': dtypes.LODCM,
+                   'KBOMirror': KBOMirror, 'OffsetMirror': XOffsetMirror,
+                   'PIM': dtypes.PIM, 'PPSStopper': PPSStopper,
+                   'PulsePicker': dtypes.PulsePicker, 'Slit': dtypes.Slits,
+                   'Stopper': dtypes.Stopper, 'XFLS': dtypes.XFLS}
 
     def __init__(self, controller, beamline=None,
                  parent=None, dark=True):
@@ -100,15 +103,15 @@ class LightApp(Display):
         self.destination_combo.setCurrentIndex(idx)
         # Add all of our device type options
         max_columns = 3
-        for i, row in enumerate(np.array_split(self.shown_types,
+        for i, row in enumerate(np.array_split(list(self.shown_types.items()),
                                                max_columns)):
             for j, device_type in enumerate(row):
                 # Add box to layout
-                box = QCheckBox(device_type.__name__)
+                box = QCheckBox(device_type[0])
                 box.setChecked(True)
                 self.device_types.layout().addWidget(box, j, i)
                 # Hook up box to hide function
-                self.device_buttons[box] = device_type
+                self.device_buttons[box] = device_type[1]
                 box.toggled.connect(self.filter)
         # Setup the UI
         self.change_path_display()

--- a/lightpath/ui/gui.py
+++ b/lightpath/ui/gui.py
@@ -66,6 +66,7 @@ class LightApp(Display):
         self.detail_screen = None
         self.device_buttons = dict()
         self._lock = threading.Lock()
+        self._prev_block = None
         # Create empty layout
         self.lightLayout = QHBoxLayout()
         self.lightLayout.setSpacing(1)
@@ -310,8 +311,10 @@ class LightApp(Display):
                 for widget in row:
                     widget.update_light(_in, _out)
                     # Reconsider blocking device state
-                    if device is block:
+                    if (device is self._prev_block or device is block):
                         widget.update_state()
+
+            self._prev_block = block
 
     def _destroy_lightpath_summary_signals(self, *args, **kwargs):
         """ Update all widgets in rows """

--- a/lightpath/ui/gui.py
+++ b/lightpath/ui/gui.py
@@ -21,7 +21,7 @@ from typhos import TyphosDeviceDisplay
 
 from lightpath.path import DeviceState
 
-from ..mock_devices import IPIMB, Crystal, Stopper
+from ..mock_devices import IPIMB, Crystal, Stopper, Valve
 from .widgets import LightRow
 
 logger = logging.getLogger(__name__)
@@ -55,7 +55,7 @@ class LightApp(Display):
                    'PulsePicker': dtypes.PulsePicker, 'Slit': dtypes.Slits,
                    'Stopper': dtypes.Stopper, 'XFLS': dtypes.XFLS,
                    'SIM_IPIMB': IPIMB, 'SIM_Stopper': Stopper,
-                   'SIM_Crystal': Crystal}
+                   'SIM_Crystal': Crystal, 'SIM_Valve': Valve}
 
     def __init__(self, controller, beamline=None,
                  parent=None, dark=True):

--- a/lightpath/ui/gui.py
+++ b/lightpath/ui/gui.py
@@ -124,10 +124,9 @@ class LightApp(Display):
 
     def destinations(self):
         """
-        All possible beamline destinations sorted by end point
+        All possible beamline destinations
         """
-        return sorted(list(self.light.beamlines.keys()),
-                      key=lambda x: self.light.active_path(x).range[0])
+        return list(self.light.beamlines.keys())
 
     def load_device_row(self, device):
         """

--- a/lightpath/ui/gui.py
+++ b/lightpath/ui/gui.py
@@ -217,12 +217,12 @@ class LightApp(Display):
                 self.rows.clear()
                 self.device_combo.clear()
                 self.upstream_device_combo.clear()
-            # Hide nothing when switching beamlines
-            boxes = self.device_types.children()
-            boxes.extend([self.remove_check])
-            for box in boxes:
-                if isinstance(box, QCheckBox):
-                    box.setChecked(True)
+            # # Hide nothing when switching beamlines
+            # boxes = self.device_types.children()
+            # boxes.extend([self.remove_check])
+            # for box in boxes:
+            #     if isinstance(box, QCheckBox):
+            #         box.setChecked(True)
 
             # Grab all the light rows (self.path set here)
             rows = [self.load_device_row(d)

--- a/lightpath/ui/gui.py
+++ b/lightpath/ui/gui.py
@@ -134,8 +134,8 @@ class LightApp(Display):
         Create LightRow for device
         """
         # Create two widgets
-        widgets = (LightRow(device),
-                   LightRow(device))
+        widgets = (LightRow(device, self.path),
+                   LightRow(device, self.path))
         # Condense the second
         widgets[1].condense()
         return widgets
@@ -281,6 +281,9 @@ class LightApp(Display):
                 # Update widget display
                 for widget in row:
                     widget.update_light(_in, _out)
+                    # Reconsider blocking device state
+                    if device is block:
+                        widget.update_state()
 
     def _destroy_lightpath_summary_signals(self, *args, **kwargs):
         """ Update all widgets in rows """

--- a/lightpath/ui/gui.py
+++ b/lightpath/ui/gui.py
@@ -114,8 +114,6 @@ class LightApp(Display):
         if dark:
             typhos.use_stylesheet(dark=True)
 
-        self.setWindowTitle('Lightpath')
-
     def destinations(self):
         """
         All possible beamline destinations
@@ -270,6 +268,7 @@ class LightApp(Display):
         self.update_path()
         # Update device type checkboxes
         self.update_device_types()
+        self.setWindowTitle(f'Lightpath - {self.selected_beamline()}')
 
     def ui_filename(self):
         """

--- a/lightpath/ui/gui.py
+++ b/lightpath/ui/gui.py
@@ -9,6 +9,8 @@ from functools import partial
 import numpy as np
 import pcdsdevices.device_types as dtypes
 import typhos
+from pcdsdevices.attenuator import AttBase
+from pcdsdevices.ipm import IPMMotion
 from pcdsdevices.valve import PPSStopper
 from pydm import Display
 from qtpy.QtCore import Qt
@@ -44,7 +46,7 @@ class LightApp(Display):
 
     parent : optional
     """
-    shown_types = [dtypes.Attenuator, dtypes.GateValve, dtypes.IPM,
+    shown_types = [AttBase, dtypes.GateValve, IPMMotion,
                    dtypes.LODCM, dtypes.OffsetMirror, dtypes.PIM, PPSStopper,
                    dtypes.PulsePicker, dtypes.Slits, dtypes.Stopper,
                    dtypes.XFLS]
@@ -317,7 +319,8 @@ class LightApp(Display):
         for row in self.rows:
             device = row[0].device
             # Hide if a hidden instance of a device type
-            hidden_device_type = type(device) in self.hidden_devices
+            hidden_device_type = any([isinstance(device, dtype)
+                                      for dtype in self.hidden_devices])
             # Hide if removed
             hidden_removed = (not self.remove_check.isChecked()
                               and row[0].last_state == DeviceState.Removed)

--- a/lightpath/ui/gui.py
+++ b/lightpath/ui/gui.py
@@ -115,6 +115,8 @@ class LightApp(Display):
         if dark:
             typhos.use_stylesheet(dark=True)
 
+        self.setWindowTitle('Lightpath')
+
     def destinations(self):
         """
         All possible beamline destinations sorted by end point

--- a/lightpath/ui/widgets.py
+++ b/lightpath/ui/widgets.py
@@ -107,12 +107,11 @@ class LightRow(InactiveRow):
     Basic Widget to display LightDevice information
 
     The widget shows the device information and state, updating looking at the
-    devices :attr:`.inserted` and :attr:`.removed` attributes. The
-    :attr:`.remove_button` also allows the user to remove devices by calling
-    the :meth:`.remove` method of the given device. The identical button is
-    setup if the device is determined to have an `insert` method. Finally,
-    PyDMRectangle is used to show the current path of the beam through the
-    table
+    device in the context of the path it resides in The device provided is
+    expected to implement the ``LightpathMixin`` interface provided in
+    ``pcdsdevices``.  This widget subscribes to the device's
+    ``lightpath_summary`` signal for updates.  Finally, PyDMRectangle is used
+    to show the current path of the beam through the table.
 
     Parameters
     ----------
@@ -189,6 +188,9 @@ class LightRow(InactiveRow):
         If device is inserted, not blocking (mirrors): StateColor.HalfRemoved
         If device is unknown / errored: StateColor.Error
 
+        The color of the labels should quickly point users to blocking devices,
+        while providing useful information about each device's state.
+
         Could take a color map in the future?  Colorblind support?
 
         Returns
@@ -217,11 +219,7 @@ class LightRow(InactiveRow):
         """
         Update the state label
 
-        The displayed state can be one of ``Unknown`` , ``Inserted``,
-        ``Removed`` or ``Error``, with ``Unknown`` being if the device is not
-        inserted or removed, and error being if the device is reporting as both
-        inserted and removed. The color of the label is also adjusted to either
-        green or red to quickly
+        Icon color is determined by ``LightRow.get_state_color()``.
         """
         # Interpret state
         self.last_state = find_device_state(self.device)[0]

--- a/lightpath/ui/widgets.py
+++ b/lightpath/ui/widgets.py
@@ -183,10 +183,10 @@ class LightRow(InactiveRow):
     def get_state_color(self) -> QColor:
         """
         Determine the icon color given the device state and path status
-        If device is an impediment: StateColor.Blocking
-        If device is removed: StateColor.Removed
-        If device is inserted, not blocking (mirrors): StateColor.HalfRemoved
-        If device is unknown / errored: StateColor.Error
+        If device is an impediment: state_color['blocking']
+        If device is removed: state_color['removed']
+        If device is in, not blocking (mirrors): state_color['half_removed']
+        If device is unknown / errored: state_color['error']
 
         The color of the labels should quickly point users to blocking devices,
         while providing useful information about each device's state.

--- a/lightpath/ui/widgets.py
+++ b/lightpath/ui/widgets.py
@@ -203,17 +203,17 @@ class LightRow(InactiveRow):
 
         if device_state is DeviceState.Disconnected:
             return state_colors['disconnected']
-        elif device_state is DeviceState.Error:
+        if device_state is DeviceState.Error:
             return state_colors['error']
-        elif device_state is DeviceState.Inserted:
+        if device_state is DeviceState.Inserted:
             if self.device not in blocking_devices:
                 return state_colors['half_removed']
             else:
                 return state_colors['blocking']
-        elif device_state is DeviceState.Removed:
+        if device_state is DeviceState.Removed:
             return state_colors['removed']
-        else:
-            return state_colors['unknown']
+
+        return state_colors['unknown']
 
     def update_state(self, *args, **kwargs):
         """


### PR DESCRIPTION
## Description
We're finally getting into the issues from the jira tickets!  Kinda.

- Gives the GUI a title that is not "form"
- Removes sorting of endstations to allow lazy loading of BeamPaths
- Fixes device filter area to match with `isinstance`, and no longer use factory functions from pcdsdevices. 
  - closes #144 
- Track cumulative transmission along BeamPath, and mark devices as blocking if they force total transmission below a threshold
- Color the widget based on both the device state and path state.   
  - A variety of jira tickets, including [jira1](https://jira.slac.stanford.edu/browse/LCLSECSD-143), [jira2](https://jira.slac.stanford.edu/browse/LCLSPC-135), [jira3](https://jira.slac.stanford.edu/browse/LCLSECSD-748)

Also in a more minor sense
- Fixes test suite fa4 deprecation warnings
- updates some docstrings and type hints
- updates tests
  - tests for attenuation tracking and widget color updates
  - un-hard-codes `path.show_devices()` test, using regex and pain
- makes the lcls simulated facility more accessible

## Motivation and Context
closes #144 , and a few jira tickets as detailed above

<details>
  <summary>Thoughts and justifications of my decisions, to make myself feel better</summary>
  
- Accumulated transmission logic: Inserted devices can now have non-0 transmission, but should removed devices have the ability to block?
  - Currently the logic already assumes that removed devices cannot be blocking, unless there is branch mismatch
  - While it's not absurd to imagine a device that blocks when removed, I chose to punt the issue
- Now that the `LightRow` widget relies on the path and the device, are we going to have a race condition?
  - Two `LightRow` widgets and one `BeamPath` are subscribed to changes in `device.lightpath_summary`.
  - When `lightpath_summary` changes, is it possible that the `LightRow`'s update before the `BeamPath` finishes, giving us bad state information?
  - No, callbacks are processed in insertion-order, and the `BeamPath` callbacks are subscribed before the `LightRow` widgets
  - I should really draw out the subscription structure in a nice way so people don't have to go through the maze repeatedly

</details>

## How Has This Been Tested?
Interactive testing, and tests have been added to the suite.

## Where Has This Been Documented?
This PR, some docstrings, etc

## Some example screenshots
From sim mode, sim_ipimb's have an inserted transmission of 0.5, so inserting 4 drops the beam below the minimum of 0.1.  Inserted devices are now blue, and device types have been updated
<img width="1546" alt="image" src="https://user-images.githubusercontent.com/35379409/185447515-0ad0bebc-0754-4a98-84f4-75133820706f.png">

An example from XCS
<img width="1357" alt="image" src="https://user-images.githubusercontent.com/35379409/185448801-faafca3d-8b7b-4ee7-8d0a-1be67d94dc6d.png">

