### PR TITLE
WIP/TST: start by removing one test

### DIFF
--- a/lightpath/main.py
+++ b/lightpath/main.py
@@ -4,12 +4,13 @@ from pathlib import Path
 
 import coloredlogs
 import happi
-import pydm
+from qtpy.QtWidgets import QApplication
 
 import lightpath
 from lightpath.ui import LightApp
 
 logger = logging.getLogger('lightpath')
+qapp = None
 
 
 def create_arg_parser():
@@ -25,6 +26,19 @@ def create_arg_parser():
     parser.add_argument('--debug', dest='debug', action='store_true',
                         help='Show the DEBUG logging stream')
     return parser
+
+
+def get_qapp():
+    """Returns the global QApplication, creating it if necessary."""
+    global qapp
+    if qapp is None:
+        if QApplication.instance() is None:
+            logger.debug("Creating QApplication ...")
+            qapp = QApplication([])
+        else:
+            logger.debug("Using existing QApplication")
+            qapp = QApplication.instance()
+    return qapp
 
 
 def main(db, hutches):
@@ -46,7 +60,7 @@ def main(db, hutches):
         client = happi.Client(path=db)
     logger.info("Launching LCLS Lightpath ...")
     # Create PyDM Application
-    app = pydm.PyDMApplication(use_main_window=False)
+    app = get_qapp()
     # Create Lightpath UI from provided database
     lc = lightpath.LightController(client, endstations=hutches)
     lp = LightApp(lc)

--- a/lightpath/tests/test_gui.py
+++ b/lightpath/tests/test_gui.py
@@ -1,4 +1,4 @@
-# from distutils.spawn import find_executable
+from distutils.spawn import find_executable
 from unittest.mock import Mock
 
 import pytest
@@ -14,111 +14,111 @@ def lightapp(lcls_client, qtbot):
     yield lightapp
 
 
-# def test_app_buttons(lightapp: LightApp):
-#     # Create widgets
-#     assert len(lightapp.select_devices('MEC')) == 14
-#     # Setup new display
-#     mec_idx = lightapp.destination_combo.findText('MEC')
-#     lightapp.destination_combo.setCurrentIndex(mec_idx)
-#     lightapp.change_path_display()
-#     assert len(lightapp.rows) == 14
+def test_app_buttons(lightapp: LightApp):
+    # Create widgets
+    assert len(lightapp.select_devices('MEC')) == 14
+    # Setup new display
+    mec_idx = lightapp.destination_combo.findText('MEC')
+    lightapp.destination_combo.setCurrentIndex(mec_idx)
+    lightapp.change_path_display()
+    assert len(lightapp.rows) == 14
 
 
-# def test_lightpath_launch_script():
-#     # Check that the executable was installed
-#     assert find_executable('lightpath')
+def test_lightpath_launch_script():
+    # Check that the executable was installed
+    assert find_executable('lightpath')
 
 
-# def test_focus_on_device(lightapp: LightApp, monkeypatch):
-#     row = lightapp.rows[7][0]
-#     monkeypatch.setattr(lightapp.scroll,
-#                         'ensureWidgetVisible',
-#                         Mock())
-#     # Grab the focus
-#     lightapp.focus_on_device(name=row.device.name)
-#     lightapp.scroll.ensureWidgetVisible.assert_called_with(row)
-#     # Go to impediment if no device is provided
-#     first_row = lightapp.rows[1][0]
-#     first_row.device.insert()
-#     lightapp.focus_on_device()
-#     lightapp.scroll.ensureWidgetVisible.assert_called_with(first_row)
-#     # Smoke test a bad device string
-#     lightapp.focus_on_device('blah')
+def test_focus_on_device(lightapp: LightApp, monkeypatch):
+    row = lightapp.rows[7][0]
+    monkeypatch.setattr(lightapp.scroll,
+                        'ensureWidgetVisible',
+                        Mock())
+    # Grab the focus
+    lightapp.focus_on_device(name=row.device.name)
+    lightapp.scroll.ensureWidgetVisible.assert_called_with(row)
+    # Go to impediment if no device is provided
+    first_row = lightapp.rows[1][0]
+    first_row.device.insert()
+    lightapp.focus_on_device()
+    lightapp.scroll.ensureWidgetVisible.assert_called_with(first_row)
+    # Smoke test a bad device string
+    lightapp.focus_on_device('blah')
 
 
-# def test_upstream_check(lightapp: LightApp, monkeypatch):
-#     assert len(lightapp.select_devices('TMO')) == 12
+def test_upstream_check(lightapp: LightApp, monkeypatch):
+    assert len(lightapp.select_devices('TMO')) == 12
 
-#     tmo_idx = lightapp.destination_combo.findText('TMO')
-#     lightapp.destination_combo.setCurrentIndex(tmo_idx)
-#     lightapp.change_path_display()
-#     assert len(lightapp.rows) == 12
+    tmo_idx = lightapp.destination_combo.findText('TMO')
+    lightapp.destination_combo.setCurrentIndex(tmo_idx)
+    lightapp.change_path_display()
+    assert len(lightapp.rows) == 12
 
+    # Create mock functions
+    for row in lightapp.rows:
+        monkeypatch.setattr(row[0], 'setHidden', Mock())
+
+    lightapp.upstream_device_combo.setCurrentIndex(5)
+    lightapp.update_upstream()
+    upstream_from_device = lightapp.light.active_path('TMO').path[5]
+    for row in lightapp.rows:
+        if (row[0].device.md.z < upstream_from_device.md.z):
+            row[0].setHidden.assert_called_with(True)
+        else:
+            row[0].setHidden.assert_called_with(False)
+
+
+# def test_filtering(lightapp: LightApp, monkeypatch):
+#     lightapp.destination_combo.setCurrentIndex(4)  # set current to MEC
 #     # Create mock functions
 #     for row in lightapp.rows:
 #         monkeypatch.setattr(row[0], 'setHidden', Mock())
-
-#     lightapp.upstream_device_combo.setCurrentIndex(5)
-#     lightapp.update_upstream()
-#     upstream_from_device = lightapp.light.active_path('TMO').path[5]
+#     # Initialize properly with nothing hidden
+#     lightapp.filter()
 #     for row in lightapp.rows:
-#         if (row[0].device.md.z < upstream_from_device.md.z):
+#         row[0].setHidden.assert_called_with(False)
+#     # Insert at least one device then hide
+#     device_row = lightapp.rows[2][0]
+#     device_row.device.insert()
+#     lightapp.remove_check.setChecked(False)
+#     # Reset mock
+#     for row in lightapp.rows:
+#         row[0].setHidden.reset_mock()
+#     lightapp.filter()
+#     for row in lightapp.rows:
+#         if row[0].device.get_lightpath_state().removed:
+#             row[0].setHidden.assert_called_with(True)
+#         else:
+#             row[0].setHidden.assert_called_with(False)
+#     # Hide upstream devices
+#     lightapp.select_devices('MEC')
+#     lightapp.remove_check.setChecked(True)
+#     lightapp.filter()
+#     for row in lightapp.rows:
+#         if row[0].device not in lightapp.light.active_path('MEC').path:
+#             row[0].setHidden.assert_called_with(True)
+#         else:
+#             row[0].setHidden.assert_called_with(False)
+#     # Dual hidden categories will not fight
+#     lightapp.remove_check.setChecked(False)
+#     lightapp.filter()
+#     for row in lightapp.rows:
+#         if ((row[0].device not in lightapp.light.active_path('MEC').path)
+#                 or (row[0].device.get_lightpath_state().removed)):
 #             row[0].setHidden.assert_called_with(True)
 #         else:
 #             row[0].setHidden.assert_called_with(False)
 
 
-def test_filtering(lightapp: LightApp, monkeypatch):
-    lightapp.destination_combo.setCurrentIndex(4)  # set current to MEC
-    # Create mock functions
-    for row in lightapp.rows:
-        monkeypatch.setattr(row[0], 'setHidden', Mock())
-    # Initialize properly with nothing hidden
-    lightapp.filter()
-    for row in lightapp.rows:
-        row[0].setHidden.assert_called_with(False)
-    # Insert at least one device then hide
-    device_row = lightapp.rows[2][0]
-    device_row.device.insert()
-    lightapp.remove_check.setChecked(False)
-    # Reset mock
-    for row in lightapp.rows:
-        row[0].setHidden.reset_mock()
-    lightapp.filter()
-    for row in lightapp.rows:
-        if row[0].device.get_lightpath_state().removed:
-            row[0].setHidden.assert_called_with(True)
-        else:
-            row[0].setHidden.assert_called_with(False)
-    # Hide upstream devices
-    lightapp.select_devices('MEC')
-    lightapp.remove_check.setChecked(True)
-    lightapp.filter()
-    for row in lightapp.rows:
-        if row[0].device not in lightapp.light.active_path('MEC').path:
-            row[0].setHidden.assert_called_with(True)
-        else:
-            row[0].setHidden.assert_called_with(False)
-    # Dual hidden categories will not fight
-    lightapp.remove_check.setChecked(False)
-    lightapp.filter()
-    for row in lightapp.rows:
-        if ((row[0].device not in lightapp.light.active_path('MEC').path)
-                or (row[0].device.get_lightpath_state().removed)):
-            row[0].setHidden.assert_called_with(True)
-        else:
-            row[0].setHidden.assert_called_with(False)
-
-
-def test_typhos_display(lightapp: LightApp):
-    # Smoke test the hide button without a detailed display
-    lightapp.hide_detailed()
-    assert lightapp.detail_layout.count() == 2
-    assert lightapp.device_detail.isHidden()
-    lightapp.show_detailed(lightapp.rows[0][0].device)
-    assert lightapp.detail_layout.count() == 3
-    assert not lightapp.device_detail.isHidden()
-    # Smoke test the hide button without a detailed display
-    lightapp.hide_detailed()
-    assert lightapp.detail_layout.count() == 2
-    assert lightapp.device_detail.isHidden()
+# def test_typhos_display(lightapp: LightApp):
+#     # Smoke test the hide button without a detailed display
+#     lightapp.hide_detailed()
+#     assert lightapp.detail_layout.count() == 2
+#     assert lightapp.device_detail.isHidden()
+#     lightapp.show_detailed(lightapp.rows[0][0].device)
+#     assert lightapp.detail_layout.count() == 3
+#     assert not lightapp.device_detail.isHidden()
+#     # Smoke test the hide button without a detailed display
+#     lightapp.hide_detailed()
+#     assert lightapp.detail_layout.count() == 2
+#     assert lightapp.device_detail.isHidden()

--- a/lightpath/tests/test_gui.py
+++ b/lightpath/tests/test_gui.py
@@ -115,12 +115,12 @@ def test_typhos_display(qtbot, lightapp: LightApp):
     lightapp.hide_detailed()
     assert lightapp.detail_layout.count() == 2
     assert lightapp.device_detail.isHidden()
-    lightapp.show_detailed(lightapp.rows[0][0].device)
-    assert lightapp.detail_layout.count() == 3
-    # add this other widget to qtbot for cleanup
-    qtbot.addWidget(lightapp.detail_layout.itemAt(1).widget())
-    assert not lightapp.device_detail.isHidden()
-    # Smoke test the hide button without a detailed display
-    lightapp.hide_detailed()
+    # lightapp.show_detailed(lightapp.rows[0][0].device)
+    # assert lightapp.detail_layout.count() == 3
+    # # add this other widget to qtbot for cleanup
+    # qtbot.addWidget(lightapp.detail_layout.itemAt(1).widget())
+    # assert not lightapp.device_detail.isHidden()
+    # # Smoke test the hide button without a detailed display
+    # lightapp.hide_detailed()
     assert lightapp.detail_layout.count() == 2
     assert lightapp.device_detail.isHidden()

--- a/lightpath/tests/test_gui.py
+++ b/lightpath/tests/test_gui.py
@@ -110,15 +110,17 @@ def test_filtering(lightapp: LightApp, monkeypatch):
             row[0].setHidden.assert_called_with(False)
 
 
-# def test_typhos_display(lightapp: LightApp):
-#     # Smoke test the hide button without a detailed display
-#     lightapp.hide_detailed()
-#     assert lightapp.detail_layout.count() == 2
-#     assert lightapp.device_detail.isHidden()
-#     lightapp.show_detailed(lightapp.rows[0][0].device)
-#     assert lightapp.detail_layout.count() == 3
-#     assert not lightapp.device_detail.isHidden()
-#     # Smoke test the hide button without a detailed display
-#     lightapp.hide_detailed()
-#     assert lightapp.detail_layout.count() == 2
-#     assert lightapp.device_detail.isHidden()
+def test_typhos_display(qtbot, lightapp: LightApp):
+    # Smoke test the hide button without a detailed display
+    lightapp.hide_detailed()
+    assert lightapp.detail_layout.count() == 2
+    assert lightapp.device_detail.isHidden()
+    lightapp.show_detailed(lightapp.rows[0][0].device)
+    assert lightapp.detail_layout.count() == 3
+    # add this other widget to qtbot for cleanup
+    qtbot.addWidget(lightapp.detail_layout.itemAt(1))
+    assert not lightapp.device_detail.isHidden()
+    # Smoke test the hide button without a detailed display
+    lightapp.hide_detailed()
+    assert lightapp.detail_layout.count() == 2
+    assert lightapp.device_detail.isHidden()

--- a/lightpath/tests/test_gui.py
+++ b/lightpath/tests/test_gui.py
@@ -1,124 +1,124 @@
-from distutils.spawn import find_executable
-from unittest.mock import Mock
+# from distutils.spawn import find_executable
+# from unittest.mock import Mock
 
-import pytest
+# import pytest
 
-from lightpath.controller import LightController
-from lightpath.ui import LightApp
-
-
-@pytest.fixture(scope='function')
-def lightapp(lcls_client, qtbot):
-    lightapp = LightApp(LightController(lcls_client))
-    qtbot.addWidget(lightapp)
-    yield lightapp
+# from lightpath.controller import LightController
+# from lightpath.ui import LightApp
 
 
-def test_app_buttons(lightapp: LightApp):
-    # Create widgets
-    assert len(lightapp.select_devices('MEC')) == 14
-    # Setup new display
-    mec_idx = lightapp.destination_combo.findText('MEC')
-    lightapp.destination_combo.setCurrentIndex(mec_idx)
-    lightapp.change_path_display()
-    assert len(lightapp.rows) == 14
+# @pytest.fixture(scope='function')
+# def lightapp(lcls_client, qtbot):
+#     lightapp = LightApp(LightController(lcls_client))
+#     qtbot.addWidget(lightapp)
+#     yield lightapp
 
 
-def test_lightpath_launch_script():
-    # Check that the executable was installed
-    assert find_executable('lightpath')
+# def test_app_buttons(lightapp: LightApp):
+#     # Create widgets
+#     assert len(lightapp.select_devices('MEC')) == 14
+#     # Setup new display
+#     mec_idx = lightapp.destination_combo.findText('MEC')
+#     lightapp.destination_combo.setCurrentIndex(mec_idx)
+#     lightapp.change_path_display()
+#     assert len(lightapp.rows) == 14
 
 
-def test_focus_on_device(lightapp: LightApp, monkeypatch):
-    row = lightapp.rows[7][0]
-    monkeypatch.setattr(lightapp.scroll,
-                        'ensureWidgetVisible',
-                        Mock())
-    # Grab the focus
-    lightapp.focus_on_device(name=row.device.name)
-    lightapp.scroll.ensureWidgetVisible.assert_called_with(row)
-    # Go to impediment if no device is provided
-    first_row = lightapp.rows[1][0]
-    first_row.device.insert()
-    lightapp.focus_on_device()
-    lightapp.scroll.ensureWidgetVisible.assert_called_with(first_row)
-    # Smoke test a bad device string
-    lightapp.focus_on_device('blah')
+# def test_lightpath_launch_script():
+#     # Check that the executable was installed
+#     assert find_executable('lightpath')
 
 
-def test_upstream_check(lightapp: LightApp, monkeypatch):
-    assert len(lightapp.select_devices('TMO')) == 12
-
-    tmo_idx = lightapp.destination_combo.findText('TMO')
-    lightapp.destination_combo.setCurrentIndex(tmo_idx)
-    lightapp.change_path_display()
-    assert len(lightapp.rows) == 12
-
-    # Create mock functions
-    for row in lightapp.rows:
-        monkeypatch.setattr(row[0], 'setHidden', Mock())
-
-    lightapp.upstream_device_combo.setCurrentIndex(5)
-    lightapp.update_upstream()
-    upstream_from_device = lightapp.light.active_path('TMO').path[5]
-    for row in lightapp.rows:
-        if (row[0].device.md.z < upstream_from_device.md.z):
-            row[0].setHidden.assert_called_with(True)
-        else:
-            row[0].setHidden.assert_called_with(False)
+# def test_focus_on_device(lightapp: LightApp, monkeypatch):
+#     row = lightapp.rows[7][0]
+#     monkeypatch.setattr(lightapp.scroll,
+#                         'ensureWidgetVisible',
+#                         Mock())
+#     # Grab the focus
+#     lightapp.focus_on_device(name=row.device.name)
+#     lightapp.scroll.ensureWidgetVisible.assert_called_with(row)
+#     # Go to impediment if no device is provided
+#     first_row = lightapp.rows[1][0]
+#     first_row.device.insert()
+#     lightapp.focus_on_device()
+#     lightapp.scroll.ensureWidgetVisible.assert_called_with(first_row)
+#     # Smoke test a bad device string
+#     lightapp.focus_on_device('blah')
 
 
-def test_filtering(lightapp: LightApp, monkeypatch):
-    lightapp.destination_combo.setCurrentIndex(4)  # set current to MEC
-    # Create mock functions
-    for row in lightapp.rows:
-        monkeypatch.setattr(row[0], 'setHidden', Mock())
-    # Initialize properly with nothing hidden
-    lightapp.filter()
-    for row in lightapp.rows:
-        row[0].setHidden.assert_called_with(False)
-    # Insert at least one device then hide
-    device_row = lightapp.rows[2][0]
-    device_row.device.insert()
-    lightapp.remove_check.setChecked(False)
-    # Reset mock
-    for row in lightapp.rows:
-        row[0].setHidden.reset_mock()
-    lightapp.filter()
-    for row in lightapp.rows:
-        if row[0].device.get_lightpath_state().removed:
-            row[0].setHidden.assert_called_with(True)
-        else:
-            row[0].setHidden.assert_called_with(False)
-    # Hide upstream devices
-    lightapp.select_devices('MEC')
-    lightapp.remove_check.setChecked(True)
-    lightapp.filter()
-    for row in lightapp.rows:
-        if row[0].device not in lightapp.light.active_path('MEC').path:
-            row[0].setHidden.assert_called_with(True)
-        else:
-            row[0].setHidden.assert_called_with(False)
-    # Dual hidden categories will not fight
-    lightapp.remove_check.setChecked(False)
-    lightapp.filter()
-    for row in lightapp.rows:
-        if ((row[0].device not in lightapp.light.active_path('MEC').path)
-                or (row[0].device.get_lightpath_state().removed)):
-            row[0].setHidden.assert_called_with(True)
-        else:
-            row[0].setHidden.assert_called_with(False)
+# def test_upstream_check(lightapp: LightApp, monkeypatch):
+#     assert len(lightapp.select_devices('TMO')) == 12
+
+#     tmo_idx = lightapp.destination_combo.findText('TMO')
+#     lightapp.destination_combo.setCurrentIndex(tmo_idx)
+#     lightapp.change_path_display()
+#     assert len(lightapp.rows) == 12
+
+#     # Create mock functions
+#     for row in lightapp.rows:
+#         monkeypatch.setattr(row[0], 'setHidden', Mock())
+
+#     lightapp.upstream_device_combo.setCurrentIndex(5)
+#     lightapp.update_upstream()
+#     upstream_from_device = lightapp.light.active_path('TMO').path[5]
+#     for row in lightapp.rows:
+#         if (row[0].device.md.z < upstream_from_device.md.z):
+#             row[0].setHidden.assert_called_with(True)
+#         else:
+#             row[0].setHidden.assert_called_with(False)
 
 
-def test_typhos_display(lightapp: LightApp):
-    # Smoke test the hide button without a detailed display
-    lightapp.hide_detailed()
-    assert lightapp.detail_layout.count() == 2
-    assert lightapp.device_detail.isHidden()
-    lightapp.show_detailed(lightapp.rows[0][0].device)
-    assert lightapp.detail_layout.count() == 3
-    assert not lightapp.device_detail.isHidden()
-    # Smoke test the hide button without a detailed display
-    lightapp.hide_detailed()
-    assert lightapp.detail_layout.count() == 2
-    assert lightapp.device_detail.isHidden()
+# def test_filtering(lightapp: LightApp, monkeypatch):
+#     lightapp.destination_combo.setCurrentIndex(4)  # set current to MEC
+#     # Create mock functions
+#     for row in lightapp.rows:
+#         monkeypatch.setattr(row[0], 'setHidden', Mock())
+#     # Initialize properly with nothing hidden
+#     lightapp.filter()
+#     for row in lightapp.rows:
+#         row[0].setHidden.assert_called_with(False)
+#     # Insert at least one device then hide
+#     device_row = lightapp.rows[2][0]
+#     device_row.device.insert()
+#     lightapp.remove_check.setChecked(False)
+#     # Reset mock
+#     for row in lightapp.rows:
+#         row[0].setHidden.reset_mock()
+#     lightapp.filter()
+#     for row in lightapp.rows:
+#         if row[0].device.get_lightpath_state().removed:
+#             row[0].setHidden.assert_called_with(True)
+#         else:
+#             row[0].setHidden.assert_called_with(False)
+#     # Hide upstream devices
+#     lightapp.select_devices('MEC')
+#     lightapp.remove_check.setChecked(True)
+#     lightapp.filter()
+#     for row in lightapp.rows:
+#         if row[0].device not in lightapp.light.active_path('MEC').path:
+#             row[0].setHidden.assert_called_with(True)
+#         else:
+#             row[0].setHidden.assert_called_with(False)
+#     # Dual hidden categories will not fight
+#     lightapp.remove_check.setChecked(False)
+#     lightapp.filter()
+#     for row in lightapp.rows:
+#         if ((row[0].device not in lightapp.light.active_path('MEC').path)
+#                 or (row[0].device.get_lightpath_state().removed)):
+#             row[0].setHidden.assert_called_with(True)
+#         else:
+#             row[0].setHidden.assert_called_with(False)
+
+
+# def test_typhos_display(lightapp: LightApp):
+#     # Smoke test the hide button without a detailed display
+#     lightapp.hide_detailed()
+#     assert lightapp.detail_layout.count() == 2
+#     assert lightapp.device_detail.isHidden()
+#     lightapp.show_detailed(lightapp.rows[0][0].device)
+#     assert lightapp.detail_layout.count() == 3
+#     assert not lightapp.device_detail.isHidden()
+#     # Smoke test the hide button without a detailed display
+#     lightapp.hide_detailed()
+#     assert lightapp.detail_layout.count() == 2
+#     assert lightapp.device_detail.isHidden()

--- a/lightpath/tests/test_gui.py
+++ b/lightpath/tests/test_gui.py
@@ -1,17 +1,17 @@
 # from distutils.spawn import find_executable
-# from unittest.mock import Mock
+from unittest.mock import Mock
 
-# import pytest
+import pytest
 
-# from lightpath.controller import LightController
-# from lightpath.ui import LightApp
+from lightpath.controller import LightController
+from lightpath.ui import LightApp
 
 
-# @pytest.fixture(scope='function')
-# def lightapp(lcls_client, qtbot):
-#     lightapp = LightApp(LightController(lcls_client))
-#     qtbot.addWidget(lightapp)
-#     yield lightapp
+@pytest.fixture(scope='function')
+def lightapp(lcls_client, qtbot):
+    lightapp = LightApp(LightController(lcls_client))
+    qtbot.addWidget(lightapp)
+    yield lightapp
 
 
 # def test_app_buttons(lightapp: LightApp):
@@ -68,57 +68,57 @@
 #             row[0].setHidden.assert_called_with(False)
 
 
-# def test_filtering(lightapp: LightApp, monkeypatch):
-#     lightapp.destination_combo.setCurrentIndex(4)  # set current to MEC
-#     # Create mock functions
-#     for row in lightapp.rows:
-#         monkeypatch.setattr(row[0], 'setHidden', Mock())
-#     # Initialize properly with nothing hidden
-#     lightapp.filter()
-#     for row in lightapp.rows:
-#         row[0].setHidden.assert_called_with(False)
-#     # Insert at least one device then hide
-#     device_row = lightapp.rows[2][0]
-#     device_row.device.insert()
-#     lightapp.remove_check.setChecked(False)
-#     # Reset mock
-#     for row in lightapp.rows:
-#         row[0].setHidden.reset_mock()
-#     lightapp.filter()
-#     for row in lightapp.rows:
-#         if row[0].device.get_lightpath_state().removed:
-#             row[0].setHidden.assert_called_with(True)
-#         else:
-#             row[0].setHidden.assert_called_with(False)
-#     # Hide upstream devices
-#     lightapp.select_devices('MEC')
-#     lightapp.remove_check.setChecked(True)
-#     lightapp.filter()
-#     for row in lightapp.rows:
-#         if row[0].device not in lightapp.light.active_path('MEC').path:
-#             row[0].setHidden.assert_called_with(True)
-#         else:
-#             row[0].setHidden.assert_called_with(False)
-#     # Dual hidden categories will not fight
-#     lightapp.remove_check.setChecked(False)
-#     lightapp.filter()
-#     for row in lightapp.rows:
-#         if ((row[0].device not in lightapp.light.active_path('MEC').path)
-#                 or (row[0].device.get_lightpath_state().removed)):
-#             row[0].setHidden.assert_called_with(True)
-#         else:
-#             row[0].setHidden.assert_called_with(False)
+def test_filtering(lightapp: LightApp, monkeypatch):
+    lightapp.destination_combo.setCurrentIndex(4)  # set current to MEC
+    # Create mock functions
+    for row in lightapp.rows:
+        monkeypatch.setattr(row[0], 'setHidden', Mock())
+    # Initialize properly with nothing hidden
+    lightapp.filter()
+    for row in lightapp.rows:
+        row[0].setHidden.assert_called_with(False)
+    # Insert at least one device then hide
+    device_row = lightapp.rows[2][0]
+    device_row.device.insert()
+    lightapp.remove_check.setChecked(False)
+    # Reset mock
+    for row in lightapp.rows:
+        row[0].setHidden.reset_mock()
+    lightapp.filter()
+    for row in lightapp.rows:
+        if row[0].device.get_lightpath_state().removed:
+            row[0].setHidden.assert_called_with(True)
+        else:
+            row[0].setHidden.assert_called_with(False)
+    # Hide upstream devices
+    lightapp.select_devices('MEC')
+    lightapp.remove_check.setChecked(True)
+    lightapp.filter()
+    for row in lightapp.rows:
+        if row[0].device not in lightapp.light.active_path('MEC').path:
+            row[0].setHidden.assert_called_with(True)
+        else:
+            row[0].setHidden.assert_called_with(False)
+    # Dual hidden categories will not fight
+    lightapp.remove_check.setChecked(False)
+    lightapp.filter()
+    for row in lightapp.rows:
+        if ((row[0].device not in lightapp.light.active_path('MEC').path)
+                or (row[0].device.get_lightpath_state().removed)):
+            row[0].setHidden.assert_called_with(True)
+        else:
+            row[0].setHidden.assert_called_with(False)
 
 
-# def test_typhos_display(lightapp: LightApp):
-#     # Smoke test the hide button without a detailed display
-#     lightapp.hide_detailed()
-#     assert lightapp.detail_layout.count() == 2
-#     assert lightapp.device_detail.isHidden()
-#     lightapp.show_detailed(lightapp.rows[0][0].device)
-#     assert lightapp.detail_layout.count() == 3
-#     assert not lightapp.device_detail.isHidden()
-#     # Smoke test the hide button without a detailed display
-#     lightapp.hide_detailed()
-#     assert lightapp.detail_layout.count() == 2
-#     assert lightapp.device_detail.isHidden()
+def test_typhos_display(lightapp: LightApp):
+    # Smoke test the hide button without a detailed display
+    lightapp.hide_detailed()
+    assert lightapp.detail_layout.count() == 2
+    assert lightapp.device_detail.isHidden()
+    lightapp.show_detailed(lightapp.rows[0][0].device)
+    assert lightapp.detail_layout.count() == 3
+    assert not lightapp.device_detail.isHidden()
+    # Smoke test the hide button without a detailed display
+    lightapp.hide_detailed()
+    assert lightapp.detail_layout.count() == 2
+    assert lightapp.device_detail.isHidden()

--- a/lightpath/tests/test_gui.py
+++ b/lightpath/tests/test_gui.py
@@ -115,12 +115,12 @@ def test_typhos_display(qtbot, lightapp: LightApp):
     lightapp.hide_detailed()
     assert lightapp.detail_layout.count() == 2
     assert lightapp.device_detail.isHidden()
-    # lightapp.show_detailed(lightapp.rows[0][0].device)
-    # assert lightapp.detail_layout.count() == 3
-    # # add this other widget to qtbot for cleanup
-    # qtbot.addWidget(lightapp.detail_layout.itemAt(1).widget())
-    # assert not lightapp.device_detail.isHidden()
-    # # Smoke test the hide button without a detailed display
-    # lightapp.hide_detailed()
+    lightapp.show_detailed(lightapp.rows[0][0].device)
+    assert lightapp.detail_layout.count() == 3
+    # add this other widget to qtbot for cleanup
+    qtbot.addWidget(lightapp.detail_layout.itemAt(1).widget())
+    assert not lightapp.device_detail.isHidden()
+    # Smoke test the hide button without a detailed display
+    lightapp.hide_detailed()
     assert lightapp.detail_layout.count() == 2
     assert lightapp.device_detail.isHidden()

--- a/lightpath/tests/test_gui.py
+++ b/lightpath/tests/test_gui.py
@@ -118,7 +118,7 @@ def test_typhos_display(qtbot, lightapp: LightApp):
     lightapp.show_detailed(lightapp.rows[0][0].device)
     assert lightapp.detail_layout.count() == 3
     # add this other widget to qtbot for cleanup
-    qtbot.addWidget(lightapp.detail_layout.itemAt(1))
+    qtbot.addWidget(lightapp.detail_layout.itemAt(1).widget())
     assert not lightapp.device_detail.isHidden()
     # Smoke test the hide button without a detailed display
     lightapp.hide_detailed()

--- a/lightpath/tests/test_gui.py
+++ b/lightpath/tests/test_gui.py
@@ -68,46 +68,46 @@ def test_upstream_check(lightapp: LightApp, monkeypatch):
             row[0].setHidden.assert_called_with(False)
 
 
-# def test_filtering(lightapp: LightApp, monkeypatch):
-#     lightapp.destination_combo.setCurrentIndex(4)  # set current to MEC
-#     # Create mock functions
-#     for row in lightapp.rows:
-#         monkeypatch.setattr(row[0], 'setHidden', Mock())
-#     # Initialize properly with nothing hidden
-#     lightapp.filter()
-#     for row in lightapp.rows:
-#         row[0].setHidden.assert_called_with(False)
-#     # Insert at least one device then hide
-#     device_row = lightapp.rows[2][0]
-#     device_row.device.insert()
-#     lightapp.remove_check.setChecked(False)
-#     # Reset mock
-#     for row in lightapp.rows:
-#         row[0].setHidden.reset_mock()
-#     lightapp.filter()
-#     for row in lightapp.rows:
-#         if row[0].device.get_lightpath_state().removed:
-#             row[0].setHidden.assert_called_with(True)
-#         else:
-#             row[0].setHidden.assert_called_with(False)
-#     # Hide upstream devices
-#     lightapp.select_devices('MEC')
-#     lightapp.remove_check.setChecked(True)
-#     lightapp.filter()
-#     for row in lightapp.rows:
-#         if row[0].device not in lightapp.light.active_path('MEC').path:
-#             row[0].setHidden.assert_called_with(True)
-#         else:
-#             row[0].setHidden.assert_called_with(False)
-#     # Dual hidden categories will not fight
-#     lightapp.remove_check.setChecked(False)
-#     lightapp.filter()
-#     for row in lightapp.rows:
-#         if ((row[0].device not in lightapp.light.active_path('MEC').path)
-#                 or (row[0].device.get_lightpath_state().removed)):
-#             row[0].setHidden.assert_called_with(True)
-#         else:
-#             row[0].setHidden.assert_called_with(False)
+def test_filtering(lightapp: LightApp, monkeypatch):
+    lightapp.destination_combo.setCurrentIndex(4)  # set current to MEC
+    # Create mock functions
+    for row in lightapp.rows:
+        monkeypatch.setattr(row[0], 'setHidden', Mock())
+    # Initialize properly with nothing hidden
+    lightapp.filter()
+    for row in lightapp.rows:
+        row[0].setHidden.assert_called_with(False)
+    # Insert at least one device then hide
+    device_row = lightapp.rows[2][0]
+    device_row.device.insert()
+    lightapp.remove_check.setChecked(False)
+    # Reset mock
+    for row in lightapp.rows:
+        row[0].setHidden.reset_mock()
+    lightapp.filter()
+    for row in lightapp.rows:
+        if row[0].device.get_lightpath_state().removed:
+            row[0].setHidden.assert_called_with(True)
+        else:
+            row[0].setHidden.assert_called_with(False)
+    # Hide upstream devices
+    lightapp.select_devices('MEC')
+    lightapp.remove_check.setChecked(True)
+    lightapp.filter()
+    for row in lightapp.rows:
+        if row[0].device not in lightapp.light.active_path('MEC').path:
+            row[0].setHidden.assert_called_with(True)
+        else:
+            row[0].setHidden.assert_called_with(False)
+    # Dual hidden categories will not fight
+    lightapp.remove_check.setChecked(False)
+    lightapp.filter()
+    for row in lightapp.rows:
+        if ((row[0].device not in lightapp.light.active_path('MEC').path)
+                or (row[0].device.get_lightpath_state().removed)):
+            row[0].setHidden.assert_called_with(True)
+        else:
+            row[0].setHidden.assert_called_with(False)
 
 
 # def test_typhos_display(lightapp: LightApp):

--- a/lightpath/tests/test_path.py
+++ b/lightpath/tests/test_path.py
@@ -240,6 +240,6 @@ def test_summary_signal(device: Device):
 
 
 # regex patterns for show_devices test
-header_pattern = (r'^\| Name *\| Prefix *\| Position *\| Input Branches *'
-                  r'\| Output Branches *\| *State \|$')
-body_pattern = r'^\| {} *\| {} *\| *{:.5f} *\| *{} \| *{} \| Removed \|$'
+header_pattern = (r'^\| *Name *\| *Prefix *\| *Position *\| *Input Branches *'
+                  r'\| *Output Branches *\| *State *\|$')
+body_pattern = r'^\| *{} *\| *{} *\| *{:.5f} *\| *{} *\| *{} *\| *Removed *\|$'

--- a/lightpath/tests/test_widgets.py
+++ b/lightpath/tests/test_widgets.py
@@ -5,8 +5,7 @@ from ophyd import Device
 
 from lightpath import BeamPath
 from lightpath.ui import LightRow
-from lightpath.ui.widgets import (state_colors, symbol_for_device,
-                                  to_stylesheet_color)
+from lightpath.ui.widgets import symbol_for_device
 
 
 @pytest.fixture(scope='function')
@@ -19,24 +18,24 @@ def lightrow(path: BeamPath, qtbot):
     return w
 
 
-def test_widget_updates(lightrow: LightRow, path: BeamPath):
-    # inserted device may still permit beam
-    ipimb = path.path[5]
-    ipimb_row = LightRow(ipimb, path)
-    ipimb.insert()
-    assert (to_stylesheet_color(state_colors['half_removed'])
-            in ipimb_row.state_label.styleSheet())
+# def test_widget_updates(lightrow: LightRow, path: BeamPath):
+#     # inserted device may still permit beam
+#     ipimb = path.path[5]
+#     ipimb_row = LightRow(ipimb, path)
+#     ipimb.insert()
+#     assert (to_stylesheet_color(state_colors['half_removed'])
+#             in ipimb_row.state_label.styleSheet())
 
-    # Toggle device to trigger callbacks
-    lightrow.device.insert()
-    lightrow.device.remove()
-    assert (to_stylesheet_color(state_colors['removed'])
-            in lightrow.state_label.styleSheet())
-    lightrow.device.insert()
-    assert (to_stylesheet_color(state_colors['blocking'])
-            in lightrow.state_label.styleSheet())
-    # Check that callbacks have been called
-    assert lightrow.state_label.setText.called
+#     # Toggle device to trigger callbacks
+#     lightrow.device.insert()
+#     lightrow.device.remove()
+#     assert (to_stylesheet_color(state_colors['removed'])
+#             in lightrow.state_label.styleSheet())
+#     lightrow.device.insert()
+#     assert (to_stylesheet_color(state_colors['blocking'])
+#             in lightrow.state_label.styleSheet())
+#     # Check that callbacks have been called
+#     assert lightrow.state_label.setText.called
 
 
 def test_widget_icon(lightrow: LightRow):

--- a/lightpath/tests/test_widgets.py
+++ b/lightpath/tests/test_widgets.py
@@ -1,21 +1,21 @@
-from unittest.mock import Mock
+# from unittest.mock import Mock
 
-import pytest
-from ophyd import Device
+# import pytest
+# from ophyd import Device
 
-from lightpath import BeamPath
-from lightpath.ui import LightRow
-from lightpath.ui.widgets import symbol_for_device
+# from lightpath import BeamPath
+# from lightpath.ui import LightRow
+# from lightpath.ui.widgets import symbol_for_device
 
 
-@pytest.fixture(scope='function')
-def lightrow(path: BeamPath, qtbot):
-    # Generate lightpath
-    w = LightRow(path.path[3], path)
-    qtbot.addWidget(w)
-    # Replace Update functions with mocks
-    setattr(w.state_label, 'setText', Mock())
-    return w
+# @pytest.fixture(scope='function')
+# def lightrow(path: BeamPath, qtbot):
+#     # Generate lightpath
+#     w = LightRow(path.path[3], path)
+#     qtbot.addWidget(w)
+#     # Replace Update functions with mocks
+#     setattr(w.state_label, 'setText', Mock())
+#     return w
 
 
 # def test_widget_updates(lightrow: LightRow, path: BeamPath):
@@ -38,18 +38,18 @@ def lightrow(path: BeamPath, qtbot):
 #     assert lightrow.state_label.setText.called
 
 
-def test_widget_icon(lightrow: LightRow):
-    assert symbol_for_device(lightrow.device) == lightrow.device._icon
-    # Smoke test a device without an icon
-    device = Device(name='test')
-    symbol_for_device(device)
-    # Smoke test a device with a malformed icon
-    device._icon = 'definetly not an icon'
-    lr = LightRow(device, lightrow.path)
-    lr.update_state()
+# def test_widget_icon(lightrow: LightRow):
+#     assert symbol_for_device(lightrow.device) == lightrow.device._icon
+#     # Smoke test a device without an icon
+#     device = Device(name='test')
+#     symbol_for_device(device)
+#     # Smoke test a device with a malformed icon
+#     device._icon = 'definetly not an icon'
+#     lr = LightRow(device, lightrow.path)
+#     lr.update_state()
 
 
-def test_widget_hints(lightrow: LightRow):
-    hint_count = len(lightrow.device.hints['fields'])
-    # Check for label and control for each hint plus spacer
-    assert lightrow.command_layout.count() == 2 * hint_count + 1
+# def test_widget_hints(lightrow: LightRow):
+#     hint_count = len(lightrow.device.hints['fields'])
+#     # Check for label and control for each hint plus spacer
+#     assert lightrow.command_layout.count() == 2 * hint_count + 1

--- a/lightpath/tests/test_widgets.py
+++ b/lightpath/tests/test_widgets.py
@@ -1,55 +1,56 @@
-# from unittest.mock import Mock
+from unittest.mock import Mock
 
-# import pytest
-# from ophyd import Device
+import pytest
+from ophyd import Device
 
-# from lightpath import BeamPath
-# from lightpath.ui import LightRow
-# from lightpath.ui.widgets import symbol_for_device
-
-
-# @pytest.fixture(scope='function')
-# def lightrow(path: BeamPath, qtbot):
-#     # Generate lightpath
-#     w = LightRow(path.path[3], path)
-#     qtbot.addWidget(w)
-#     # Replace Update functions with mocks
-#     setattr(w.state_label, 'setText', Mock())
-#     return w
+from lightpath import BeamPath
+from lightpath.ui import LightRow
+from lightpath.ui.widgets import (state_colors, symbol_for_device,
+                                  to_stylesheet_color)
 
 
-# def test_widget_updates(lightrow: LightRow, path: BeamPath):
-#     # inserted device may still permit beam
-#     ipimb = path.path[5]
-#     ipimb_row = LightRow(ipimb, path)
-#     ipimb.insert()
-#     assert (to_stylesheet_color(state_colors['half_removed'])
-#             in ipimb_row.state_label.styleSheet())
-
-#     # Toggle device to trigger callbacks
-#     lightrow.device.insert()
-#     lightrow.device.remove()
-#     assert (to_stylesheet_color(state_colors['removed'])
-#             in lightrow.state_label.styleSheet())
-#     lightrow.device.insert()
-#     assert (to_stylesheet_color(state_colors['blocking'])
-#             in lightrow.state_label.styleSheet())
-#     # Check that callbacks have been called
-#     assert lightrow.state_label.setText.called
+@pytest.fixture(scope='function')
+def lightrow(path: BeamPath, qtbot):
+    # Generate lightpath
+    w = LightRow(path.path[3], path)
+    qtbot.addWidget(w)
+    # Replace Update functions with mocks
+    setattr(w.state_label, 'setText', Mock())
+    return w
 
 
-# def test_widget_icon(lightrow: LightRow):
-#     assert symbol_for_device(lightrow.device) == lightrow.device._icon
-#     # Smoke test a device without an icon
-#     device = Device(name='test')
-#     symbol_for_device(device)
-#     # Smoke test a device with a malformed icon
-#     device._icon = 'definetly not an icon'
-#     lr = LightRow(device, lightrow.path)
-#     lr.update_state()
+def test_widget_updates(lightrow: LightRow, path: BeamPath):
+    # inserted device may still permit beam
+    ipimb = path.path[5]
+    ipimb_row = LightRow(ipimb, path)
+    ipimb.insert()
+    assert (to_stylesheet_color(state_colors['half_removed'])
+            in ipimb_row.state_label.styleSheet())
+
+    # Toggle device to trigger callbacks
+    lightrow.device.insert()
+    lightrow.device.remove()
+    assert (to_stylesheet_color(state_colors['removed'])
+            in lightrow.state_label.styleSheet())
+    lightrow.device.insert()
+    assert (to_stylesheet_color(state_colors['blocking'])
+            in lightrow.state_label.styleSheet())
+    # Check that callbacks have been called
+    assert lightrow.state_label.setText.called
 
 
-# def test_widget_hints(lightrow: LightRow):
-#     hint_count = len(lightrow.device.hints['fields'])
-#     # Check for label and control for each hint plus spacer
-#     assert lightrow.command_layout.count() == 2 * hint_count + 1
+def test_widget_icon(lightrow: LightRow):
+    assert symbol_for_device(lightrow.device) == lightrow.device._icon
+    # Smoke test a device without an icon
+    device = Device(name='test')
+    symbol_for_device(device)
+    # Smoke test a device with a malformed icon
+    device._icon = 'definetly not an icon'
+    lr = LightRow(device, lightrow.path)
+    lr.update_state()
+
+
+def test_widget_hints(lightrow: LightRow):
+    hint_count = len(lightrow.device.hints['fields'])
+    # Check for label and control for each hint plus spacer
+    assert lightrow.command_layout.count() == 2 * hint_count + 1


### PR DESCRIPTION
## Description
poking around to try and fix the qthread teardown errors.  I saw a slightly more verbose error message that led me to think that maybe I could fix thix

Seen in the docs PR checks:
``` console
Unable to remove connection for <PyDMChannel (sig://five_current_state)>
Traceback (most recent call last):
  File "/home/travis/virtualenv/python3.9.6/lib/python3.9/site-packages/pydm/widgets/channel.py", line 130, in disconnect
    plugin.remove_connection(self, destroying=destroying)
  File "/home/travis/virtualenv/python3.9.6/lib/python3.9/site-packages/pydm/data_plugins/plugin.py", line 239, in remove_connection
    self.connections[connection_id].deleteLater()
RuntimeError: wrapped C/C++ object of type SignalConnection has been deleted
Unable to remove connection for <PyDMChannel (sig://five_current_destination)>
Traceback (most recent call last):
  File "/home/travis/virtualenv/python3.9.6/lib/python3.9/site-packages/pydm/widgets/channel.py", line 130, in disconnect
    plugin.remove_connection(self, destroying=destroying)
  File "/home/travis/virtualenv/python3.9.6/lib/python3.9/site-packages/pydm/data_plugins/plugin.py", line 239, in remove_connection
    self.connections[connection_id].deleteLater()
RuntimeError: wrapped C/C++ object of type SignalConnection has been deleted
QThread: Destroyed while thread is still running
/home/travis/.travis/functions: line 109:  5917 Aborted                 pytest "${PYTEST_ARGS[@]}"
```

## Motivation and Context
#138

## How Has This Been Tested?
Here is where I abuse travis

## Where Has This Been Documented?
This PR
