### PR TITLE
PERF: remove hinted signals from LightRow widgets

### DIFF
--- a/docs/source/upcoming_release_notes/157-perf_no_hinted_signals.rst
+++ b/docs/source/upcoming_release_notes/157-perf_no_hinted_signals.rst
@@ -1,0 +1,23 @@
+157 perf_no_hinted_signals
+##########################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- removes hinted signal widgets loaded from typhos to improve loadtimes
+- allows lightpath cli command to be run without arguments, loading all default hutches
+
+Contributors
+------------
+- tangkong

--- a/docs/source/upcoming_release_notes/157-perf_no_hinted_signals.rst
+++ b/docs/source/upcoming_release_notes/157-perf_no_hinted_signals.rst
@@ -15,7 +15,7 @@ Bugfixes
 
 Maintenance
 -----------
-- removes hinted signal widgets loaded from typhos to improve loadtimes
+- Removes hinted signal widgets loaded from typhos to improve loadtimes
 - allows lightpath cli command to be run without arguments, loading all default hutches
 
 Contributors

--- a/lightpath/main.py
+++ b/lightpath/main.py
@@ -79,9 +79,6 @@ def main(
         with open(cfg, 'r') as f:
             conf = yaml.safe_load(f)
     else:
-        if not db and not hutches:
-            raise ValueError('Need to supply either a config file or '
-                             'a list of hutches and database path.')
         conf = {}
 
     timeout = float(conf.get('timeout', 10))  # timeout (s)

--- a/lightpath/tests/test_widgets.py
+++ b/lightpath/tests/test_widgets.py
@@ -23,12 +23,13 @@ def test_widget_updates(lightrow: LightRow, path: BeamPath):
     # inserted device may still permit beam
     ipimb = path.path[5]
     ipimb_row = LightRow(ipimb, path)
+    # Toggle device to trigger callbacks
+    ipimb.insert()
+    ipimb.remove()
     ipimb.insert()
     assert (to_stylesheet_color(state_colors['half_removed'])
             in ipimb_row.state_label.styleSheet())
 
-    # Toggle device to trigger callbacks
-    lightrow.device.insert()
     lightrow.device.remove()
     assert (to_stylesheet_color(state_colors['removed'])
             in lightrow.state_label.styleSheet())
@@ -48,9 +49,3 @@ def test_widget_icon(lightrow: LightRow):
     device._icon = 'definetly not an icon'
     lr = LightRow(device, lightrow.path)
     lr.update_state()
-
-
-def test_widget_hints(lightrow: LightRow):
-    hint_count = len(lightrow.device.hints['fields'])
-    # Check for label and control for each hint plus spacer
-    assert lightrow.command_layout.count() == 2 * hint_count + 1

--- a/lightpath/ui/device.ui
+++ b/lightpath/ui/device.ui
@@ -25,7 +25,7 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,0,2">
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,0">
    <property name="sizeConstraint">
     <enum>QLayout::SetDefaultConstraint</enum>
    </property>
@@ -311,46 +311,6 @@
       </size>
      </property>
     </spacer>
-   </item>
-   <item>
-    <widget class="QFrame" name="commands">
-     <property name="frameShape">
-      <enum>QFrame::NoFrame</enum>
-     </property>
-     <property name="lineWidth">
-      <number>2</number>
-     </property>
-     <layout class="QVBoxLayout" name="command_layout">
-      <property name="spacing">
-       <number>10</number>
-      </property>
-      <property name="leftMargin">
-       <number>5</number>
-      </property>
-      <property name="topMargin">
-       <number>5</number>
-      </property>
-      <property name="rightMargin">
-       <number>5</number>
-      </property>
-      <property name="bottomMargin">
-       <number>5</number>
-      </property>
-      <item>
-       <spacer name="verticalSpacer_3">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>5</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-     </layout>
-    </widget>
    </item>
   </layout>
  </widget>

--- a/lightpath/ui/widgets.py
+++ b/lightpath/ui/widgets.py
@@ -89,9 +89,8 @@ class InactiveRow(Display):
 
     def condense(self):
         """Reduce the size of the widget when the device is hidden"""
-        # Hide commands and labels
+        # Hide and labels
         self.device_information.hide()
-        self.commands.hide()
         # Resize drawings
         self.out_indicator.hide()
         self.device_drawing.setFixedHeight(15)

--- a/lightpath/ui/widgets.py
+++ b/lightpath/ui/widgets.py
@@ -89,7 +89,7 @@ class InactiveRow(Display):
 
     def condense(self):
         """Reduce the size of the widget when the device is hidden"""
-        # Hide and labels
+        # Hide labels
         self.device_information.hide()
         # Resize drawings
         self.out_indicator.hide()


### PR DESCRIPTION
## Description
- Removes hinted signals from lightrow widgets for performance reasons
- Removes cli check requiring one of `db` or `hutches`, defaulting to all the hutches in the default config
- Removes the `command` layout, allowing device widget centering
- ?Fixes? tests. Callbacks are being weird, nothing was changed within this PR that should have affected the stylesheet test, but the command hint test was rightfully removed.

## Motivation and Context
In the quest for a faster lightpath, we found that walking and creating the signal widgets on the main screen incurred a significant time loss.  The detailed screens still exist for allowing users to control their devices from lightpath.

As measured from the command line (`time python -m lightpath --hutches XCS`)
Before this PR: ~90s 
After this PR: ~30s 

This also lets us benefit from Zach's ophyd performance PR, since we are no longer waking up each device at lightpath startup.  

This does come with the caveat that opening detailed screens for the first time will be significantly slower.  We are essentially deferring the acquisition of that resource until later.

## How Has This Been Tested?
interactively

## Where Has This Been Documented?
This PR

<img width="1260" alt="image" src="https://user-images.githubusercontent.com/35379409/190475247-8960e079-429f-4860-ab2e-9baea625c30f.png">

