### PR TITLE
ENH: support devices with multiple simultaneous outputs

### DIFF
--- a/lightpath/controller.py
+++ b/lightpath/controller.py
@@ -318,15 +318,21 @@ class LightController:
             curr_dev = self.get_device(curr)
 
             while successors:
-                out_branch = curr_dev.get_lightpath_state().output_branch
+                # get output branches that receive beam
+                out_branches = get_active_outputs(curr_dev)
+                print(curr_dev.name, out_branches)
                 connections = []
                 for succ in successors:
                     succ_dev = self.get_device(succ)
                     if succ_dev is None:
                         # reached a node without a device, (the end)
                         continue
+
                     in_branches = succ_dev.input_branches
-                    if out_branch in in_branches:
+
+                    active_links = [b for b in out_branches
+                                    if b in in_branches]
+                    if active_links:
                         connections.append(succ)
 
                 if not connections:
@@ -617,6 +623,27 @@ class LightController:
                 dev = make_mock_device(dev_data.res)
                 self.graph.nodes[device_name]['md'].dev = dev
                 return dev
+
+
+def get_active_outputs(device: Device) -> List[str]:
+    """
+    Returns a list of branch names that are receiving beam.
+    Alternatively, returns a list of branches this device is delivering
+    beam to with transmission > 0.
+
+    Parameters
+    ----------
+    device : Device
+        Device to get active output branches for
+
+    Returns
+    -------
+    List[str]
+        List of active branches
+    """
+    outputs = device.get_lightpath_state().output
+
+    return [br for br, trans in outputs.items() if trans > 0]
 
 
 def make_mock_device(result: SearchResult) -> Device:

--- a/lightpath/mock_devices.py
+++ b/lightpath/mock_devices.py
@@ -158,7 +158,7 @@ class Stopper(BaseValve):
 
 class Crystal(BaseValve):
     """
-    Generic branching device
+    Generic branching device, allowing more than 2 output branches
     """
     _icon = 'fa5.star'
     _transmission = 0.8
@@ -173,8 +173,40 @@ class Crystal(BaseValve):
         state = super().get_lightpath_state()
         if state.inserted:
             br = self._inserted_branch.get()
-            # self.current_destination.put(self.output_branches[br])
+            self.current_destination.put(self.output_branches[br])
             state.output = {self.output_branches[br]: 0.8}
+
+        elif state.removed:
+            self.current_destination.put(self.output_branches[0])
+            state.output = {self.output_branches[0]: 1}
+
+        return state
+
+
+class LODCM(BaseValve):
+    """
+    LODCM device that can allow beam to two destinations at once.
+    States are:
+
+    - OUT (0): beam passes through, LODCM is removed
+    - IN-1 (1): beam splits between two output branches
+    - IN-2 (2): beam diverted to second output branch
+    """
+
+    # when inserted, which insertion mode??
+    _inserted_mode = Cpt(Signal, value=1)
+
+    def get_lightpath_state(self):
+        state = super().get_lightpath_state()
+        if state.inserted:
+            mode = self._inserted_mode.get()
+            # self.current_destination.put(self.output_branches[br])
+            if mode == 1:
+                state.output = {self.output_branches[0]: 0.5,
+                                self.output_branches[1]: 0.5}
+            elif mode == 2:
+                state.output = {self.output_branches[0]: 0,
+                                self.output_branches[1]: 1}
 
         elif state.removed:
             # self.current_destination.put(self.output_branches[0])

--- a/lightpath/path.py
+++ b/lightpath/path.py
@@ -20,7 +20,7 @@ import logging
 import math
 from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Callable, List, Optional, TextIO, Tuple, Union
+from typing import Callable, Dict, List, Optional, TextIO, Tuple, Union
 
 from ophyd import Device, DeviceStatus
 from ophyd.ophydobj import OphydObject
@@ -28,7 +28,7 @@ from ophyd.status import wait as status_wait
 from ophyd.utils import DisconnectedError
 from prettytable import PrettyTable
 
-from .errors import CoordinateError
+from .errors import CoordinateError, PathError
 
 logger = logging.getLogger(__name__)
 
@@ -45,14 +45,12 @@ class LightpathState:
 
     removed : bool
 
-    transmission : float
-
-    output_branch : str
+    output : Dict[str, float]
+        mapping from output branch to transmission
     """
     inserted: bool
     removed: bool
-    transmission: float
-    output_branch: str
+    output: Dict[str, float]
 
 
 class DeviceState(enum.IntEnum):
@@ -193,6 +191,7 @@ class BeamPath(OphydObject):
         self.minimum_transmission = minimum_transmission
         self.devices = devices
         self._has_subscribed = False
+        self.branch_list = set()
         logger.debug("Configuring path %s with %s devices",
                      name, len(self.devices))
         # Sort by position downstream to upstream
@@ -207,6 +206,9 @@ class BeamPath(OphydObject):
                                           'initialized', dev)
                 # Add as attribute
                 setattr(self, dev.name.replace(' ', '_'), dev)
+                # Update branch list
+                for br in dev.input_branches:
+                    self.branch_list.add(br)
 
         except AttributeError as e:
             raise TypeError('One of the devices does not meet the '
@@ -229,12 +231,25 @@ class BeamPath(OphydObject):
         """ List[Device]: List of devices ordered by coordinates """
         return sorted(self.devices, key=lambda dev: dev.md.z)
 
+    def get_device_output(self, state: LightpathState) -> Tuple[str, float]:
+        # find relevant output entry
+        output_keys = [br for br in state.output.keys()
+                       if br in self.branch_list]
+
+        if len(output_keys) > 1:
+            raise PathError('device has reports multiple outputs along '
+                            f'this path: {state.output.keys()}')
+        elif len(output_keys) == 0:
+            return '', 0
+
+        return output_keys[0], state.output[output_keys[0]]
+
     @property
     def blocking_devices(self) -> List[Device]:
         """
         A list of devices that are currently inserted or are in unknown
         positions. This includes devices downstream of the first
-        :attr:`.impediment`
+        :attr:`.impediment`.
 
         Returns
         -------
@@ -243,27 +258,33 @@ class BeamPath(OphydObject):
         """
         # Cache important prior devices
         prev_device = None
-        prev_status = None
+        prev_dev_branch = None
         block = list()
         current_transmission = 1
-
         for device in self.path:
             curr_state, curr_status = find_device_state(device)
-
             # short circuit if statuses are in error
-            if curr_state in (DeviceState.Error, DeviceState.Unknown):
+            if curr_state in (DeviceState.Error, DeviceState.Unknown,
+                              DeviceState.Disconnected):
                 block.append(device)
+                continue
 
+            dev_out = self.get_device_output(curr_status)
+            curr_dev_branch, curr_dev_trans = dev_out
+            # device output not on path
+            if curr_dev_branch == '':
+                block.append(device)
             # check to make sure input and output branches match
             # e.g. mirror not pointing to current device
-            elif (prev_device is not None and prev_status is not None and
-                  prev_status.output_branch not in device.input_branches):
-                block.append(prev_device)
+            elif (prev_device is not None and prev_dev_branch is not None
+                  and prev_dev_branch not in device.input_branches):
+                if prev_device not in block:
+                    block.append(prev_device)
             # check inserted
             elif curr_state is DeviceState.Inserted:
-                if curr_status.transmission > 1:
+                if curr_dev_trans > 1:
                     logger.error(f'{device.name} reports transmission > 1')
-                current_transmission *= min(curr_status.transmission, 1)
+                current_transmission *= min(curr_dev_trans, 1)
                 # Any device seeing current transmission below min would block
                 if current_transmission < self.minimum_transmission:
                     block.append(device)
@@ -276,8 +297,7 @@ class BeamPath(OphydObject):
 
             # stash previous device
             prev_device = device
-            prev_status = curr_status
-
+            prev_dev_branch = curr_dev_branch
         return block
 
     @property
@@ -528,9 +548,10 @@ class BeamPath(OphydObject):
         # Add passive devices to ignored
         if not passive:
             logger.debug("Passive devices will be ignored ...")
-            ignore.extend([d for d in self.devices
-                           if d.get_lightpath_state().transmission >
-                           self.minimum_transmission])
+            for dev in self.devices:
+                _, trans = self.get_device_output(dev.get_lightpath_state())
+                if trans > self.minimum_transmission:
+                    ignore.append(dev)
         # Add ignored devices
         if isinstance(ignore_devices, Iterable):
             ignore.extend(ignore_devices)

--- a/lightpath/tests/conftest.py
+++ b/lightpath/tests/conftest.py
@@ -9,7 +9,8 @@ import yaml
 
 from lightpath import BeamPath
 from lightpath.controller import LightController
-from lightpath.mock_devices import IPIMB, Crystal, Stopper, Valve
+from lightpath.mock_devices import (IPIMB, LODCM, Crystal, Stopper,  # noqa
+                                    Valve)
 
 
 #################

--- a/lightpath/tests/path.json
+++ b/lightpath/tests/path.json
@@ -1337,7 +1337,7 @@
         "active": true,
         "args": ["{{prefix}}"],
         "creation": "Wed Jun 22 09:53:22 2022",
-        "device_class": "lightpath.tests.conftest.Crystal",
+        "device_class": "lightpath.tests.conftest.LODCM",
         "documentation": null,
         "input_branches": [
             "L0"
@@ -1364,7 +1364,7 @@
         "active": true,
         "args": ["{{prefix}}"],
         "creation": "Wed Jun 22 09:53:22 2022",
-        "device_class": "lightpath.tests.conftest.Crystal",
+        "device_class": "lightpath.tests.conftest.LODCM",
         "documentation": null,
         "input_branches": [
             "L0"

--- a/lightpath/tests/test_controller.py
+++ b/lightpath/tests/test_controller.py
@@ -99,6 +99,27 @@ def test_path_to(lcls_ctrl: LightController):
     mec_path == lcls_ctrl.active_path('MEC').path
 
 
+def test_multi_output(lcls_ctrl: LightController):
+    xcs_lodcm = lcls_ctrl.get_device('xcs_lodcm')
+    assert lcls_ctrl.active_path('XCS').blocking_devices == [xcs_lodcm]
+    # set lodcm to split beam
+    xcs_lodcm._inserted_mode.put(1)
+    xcs_lodcm.insert()
+
+    # no impediments, both receive beam
+    assert not lcls_ctrl.active_path('XCS').blocking_devices
+    assert not lcls_ctrl.active_path('CXI').blocking_devices
+
+    # set to diverge beam fully
+    xcs_lodcm.remove()
+    xcs_lodcm._inserted_mode.put(2)
+    xcs_lodcm.insert()
+
+    # beam goes to xcs only
+    assert not lcls_ctrl.active_path('XCS').blocking_devices
+    assert lcls_ctrl.active_path('CXI').blocking_devices == [xcs_lodcm]
+
+
 def test_walk_facility(lcls_ctrl: LightController):
     # with all removed, expect beam straight through
     walk = lcls_ctrl.walk_facility()


### PR DESCRIPTION
## Description
- changes the `LightpathState` dataclass to merge `output_branches` and `transmission` into one field: `output`
  - `output` is expected to be a dictionary mapping output branch to its transmission.  
- made changes to `LightController` and `BeamPath` to take this into account.
- adds corresponding tests (LODCM mock device, test_multi_output)
- stores the devices in a poor-man's linked list (OrderedDict) to make subsequent `BeamPath.path` calls faster.

## Motivation and Context
LODCM's support multiple simultaneous outputs, and the current lightpath did not.  

`BeamPath.path` is called by almost every method / property (`.blocking_devices`, `.incident_devices`, etc), and previously sorted the devices every time.  

The helper method (`get_device_output`) added here would have needed to find a given device's index in that path list, which scales poorly as the number of devices in a single path increases.  This gets worse as we iterate through path.  I figure if we do this calculation once, we can save time down the line.  

## How Has This Been Tested?
Test suite runs, additional test has been added.

Interactive mucking around works too

## Where Has This Been Documented?
docs will be updated shortly

<img width="1085" alt="image" src="https://user-images.githubusercontent.com/35379409/191137936-7cc26776-a140-4895-bd56-e49716fece36.png">

<img width="1084" alt="image" src="https://user-images.githubusercontent.com/35379409/191137982-d377a17b-47c7-42aa-987f-7241de7ade5f.png">


