### PR TITLE
GUI: add loading screen and refresh button

### DIFF
--- a/docs/source/upcoming_release_notes/162-gui_loading_screen.rst
+++ b/docs/source/upcoming_release_notes/162-gui_loading_screen.rst
@@ -1,0 +1,22 @@
+162 gui_loading_screen
+######################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- adds a refresh button and loading splash screen
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- fixes some clipping issues with the device icons
+
+Contributors
+------------
+- tangkong

--- a/docs/source/upcoming_release_notes/162-gui_loading_screen.rst
+++ b/docs/source/upcoming_release_notes/162-gui_loading_screen.rst
@@ -11,7 +11,7 @@ Features
 
 Bugfixes
 --------
-- N/A
+- prevent beamlines with no beampath from destination combo box
 
 Maintenance
 -----------

--- a/lightpath/ui/gui.py
+++ b/lightpath/ui/gui.py
@@ -82,6 +82,8 @@ class LightApp(Display):
         self.upstream_device_combo.activated[str].connect(self.update_upstream)
         self.remove_check.toggled.connect(self.filter)
         self.detail_hide.clicked.connect(self.hide_detailed)
+        self.refresh_button.clicked.connect(self.change_path_display)
+
         # Store LightRow objects to manage subscriptions
         self.rows = list()
         # store device type filter widgets

--- a/lightpath/ui/gui.py
+++ b/lightpath/ui/gui.py
@@ -48,7 +48,7 @@ class LightApp(Display):
                  parent=None, dark=True):
         super().__init__(parent=parent)
         # Store Lightpath information
-        self.loading_splash = LoadingSplash()
+        self.loading_splash = LoadingSplash(parent=self)
         self.light = controller
         self.path = None
         self.detail_screen = None

--- a/lightpath/ui/gui.py
+++ b/lightpath/ui/gui.py
@@ -8,10 +8,12 @@ import threading
 from functools import partial
 
 import numpy as np
+import qtawesome as qta
 import typhos
 from pydm import Display
 from qtpy.QtCore import Qt
 from qtpy.QtCore import Slot as pyqtSlot
+from qtpy.QtGui import QColor
 from qtpy.QtWidgets import (QApplication, QCheckBox, QDialog, QGridLayout,
                             QHBoxLayout, QLabel, QVBoxLayout)
 from typhos import TyphosDeviceDisplay
@@ -452,11 +454,9 @@ class LoadingSplash(QDialog):
         self.setLayout(layout)
 
         self.status_display = QLabel()
-        tout = typhos.utils.TyphosLoading.LOADING_TIMEOUT_MS
-        # No Timeout!
-        typhos.utils.TyphosLoading.LOADING_TIMEOUT_MS = -1
-        loading = typhos.utils.TyphosLoading(self)
-        typhos.utils.TyphosLoading.LOADING_TIMEOUT_MS = tout
+        loading = QLabel()
+        loading_icon = qta.icon('ri.loader-2-fill', color=QColor(0, 176, 255))
+        loading.setPixmap(loading_icon.pixmap(self.height(), self.height()))
 
         status_layout = QHBoxLayout()
         status_layout.addWidget(self.status_display)

--- a/lightpath/ui/gui.py
+++ b/lightpath/ui/gui.py
@@ -449,5 +449,4 @@ class LoadingSplash(QDialog):
 
     def update_status(self, msg):
         self.status_display.setText(f"Loading: {msg}")
-        # self.move()
         QApplication.instance().processEvents()

--- a/lightpath/ui/lightapp.ui
+++ b/lightpath/ui/lightapp.ui
@@ -68,7 +68,7 @@
     <widget class="QWidget" name="detailed" native="true">
      <layout class="QHBoxLayout" name="horizontalLayout">
       <item>
-       <layout class="QVBoxLayout" name="option_layout" stretch="1,1,3,2">
+       <layout class="QVBoxLayout" name="option_layout" stretch="1,1,3,0,2">
         <property name="spacing">
          <number>5</number>
         </property>
@@ -276,6 +276,13 @@
             </widget>
            </item>
           </layout>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="refresh_button">
+          <property name="text">
+           <string>Refresh</string>
+          </property>
          </widget>
         </item>
         <item>

--- a/lightpath/ui/widgets.py
+++ b/lightpath/ui/widgets.py
@@ -96,7 +96,8 @@ class InactiveRow(Display):
         self.device_drawing.setFixedHeight(15)
         self.device_drawing.setMaximumWidth(15)
         self.horizontalWidget.layout().setSpacing(1)
-        self.horizontalWidget.setFixedHeight(15)
+        # give pixmap enough room to not clip
+        self.horizontalWidget.setFixedHeight(20)
 
 
 class LightRow(InactiveRow):
@@ -233,6 +234,7 @@ class DeviceWidget(QLabel):
         # Default UI settings for conformity
         self.setMinimumSize(10, 10)
         self.setMaximumSize(50, 50)
+        self.setStyleSheet('padding : 0px')
 
     def setColor(self, color):
         """


### PR DESCRIPTION
## Description
- adds a simple splash screen that pops up during `change_path_display()` calls, closing #82 
- adds a refresh button, closing #159 
- hopefully fixes clipping in overview slider with condensed lightrow widgets, closing #136 

## Motivation and Context
Linked issues above.  The splash screen was shamelessly copied and modified from lucid.

I'm looking into also possibly making the detailed screen width adjustable, since it takes up a lot of room as is.  But that's for tomorrow possibly.

## How Has This Been Tested?
Both sim and real-device lightpaths have been clicked around.  

## Where Has This Been Documented?
This PR text

<img width="1195" alt="image" src="https://user-images.githubusercontent.com/35379409/192866821-76d19f5e-7d76-4d6a-8552-dd31c8a7262c.png">

![image](https://user-images.githubusercontent.com/35379409/192345044-27e377ca-8733-4351-9dad-fede42d4d74d.png)

