### PR TITLE
BUG: read the updated configuration when calling load_beamlines

### DIFF
--- a/lightpath/controller.py
+++ b/lightpath/controller.py
@@ -144,7 +144,7 @@ class LightController:
             Name of endstation to load
         """
         try:
-            end_branches = beamlines[endstation]
+            end_branches = self.cfg['beamlines'][endstation]
         except KeyError:
             logger.warning("Unable to find %s as a configured endstation, "
                            "assuming this is an invalid path", endstation)
@@ -183,6 +183,7 @@ class LightController:
         List[BeamPath]
             a list of BeamPath's to the requested endstation
         """
+        # if path exists, return it
         paths = self.beamlines[endstation]
 
         if all([isinstance(path, BeamPath) for path in paths]):

--- a/lightpath/controller.py
+++ b/lightpath/controller.py
@@ -265,6 +265,9 @@ class LightController:
             the active path
         """
         paths = self.get_paths(dest)
+        if len(paths) == 0:
+            raise PathError('No paths in facility to the '
+                            f'desired endstation: {dest}')
         if len(paths) == 1:
             return paths[0]
 

--- a/lightpath/controller.py
+++ b/lightpath/controller.py
@@ -69,14 +69,18 @@ class LightController:
         cfg: Dict[str, Any] = {}
     ):
         self.client: Client = client
-        self.cfg = {
+        config = {
             'beamlines': beamlines,
             'hutches': endstations,
             'sources': default_sources,
             'min_trans': 0.1
         }
         # update default config with provided cfg
-        self.cfg.update(cfg)
+        config.update(cfg)
+        self.beamline_config = config['beamlines']
+        self.hutches = config['hutches']
+        self.default_sources = config['sources']
+        self.min_trans = config['min_trans']
 
         # a mapping of endstation name to either a path or initialized BeamPath
         self.beamlines: Dict[str, MaybeBeamPath] = dict()
@@ -86,8 +90,7 @@ class LightController:
         # initialize graph -> self.graph
         self.load_facility()
 
-        dests = (self.cfg.get('hutches')
-                 or self.cfg.get('beamlines', {}).keys())
+        dests = (self.hutches or (self.beamline_config or {}).keys())
         # Find the requisite beamlines to reach our endstation
         for beamline in dests:
             self.load_beamline(beamline)
@@ -125,7 +128,7 @@ class LightController:
         for branch_name, branch_devs in branch_dict.items():
             subgraph = self.make_graph(
                 branch_devs,
-                sources=self.cfg.get('sources'),
+                sources=self.default_sources,
                 branch_name=branch_name
             )
             self.sources.update((n for n in subgraph
@@ -151,7 +154,7 @@ class LightController:
             Name of endstation to load
         """
         try:
-            end_branches = self.cfg['beamlines'][endstation]
+            end_branches = self.beamline_config[endstation]
         except KeyError:
             logger.warning("Unable to find %s as a configured endstation, "
                            "assuming this is an invalid path", endstation)
@@ -197,7 +200,7 @@ class LightController:
             return paths
 
         # create the BeamPaths if they have not been already
-        end_branches = self.cfg['beamlines'][endstation]
+        end_branches = self.beamline_config[endstation]
         filled_paths = []
         for path in paths:
             subgraph = self.graph.subgraph(path)
@@ -207,7 +210,7 @@ class LightController:
             bp = BeamPath(
                 *devices,
                 name=endstation,
-                minimum_transmission=self.cfg.get('min_trans')
+                minimum_transmission=self.min_trans
             )
 
             if isinstance(end_branches, dict):
@@ -458,7 +461,7 @@ class LightController:
                 BeamPath(
                     *devs,
                     name=f'{device.md.name}_path',
-                    minimum_transmission=self.cfg.get('min_trans')
+                    minimum_transmission=self.min_trans
                 )
             )
 

--- a/lightpath/controller.py
+++ b/lightpath/controller.py
@@ -105,11 +105,18 @@ class LightController:
         """
         results = self.client.search_range(key='z', start=0.0, end=math.inf,
                                            active=True, lightpath=True)
+        if len(results) < 1:
+            raise ValueError('No lightpath-active devices found')
         # gather devices by branch
         branch_dict = {}
         for res in results:
             for branch_set in (res.metadata.get('input_branches', []),
                                res.metadata.get('output_branches', [])):
+                if branch_set is None:
+                    raise ValueError(
+                        f'device {res.item.name} has no branch information, '
+                        'check to make sure your happi database is '
+                        'correctly implementing its container.')
                 for branch in branch_set:
                     branch_dict.setdefault(branch, set()).add(res)
 

--- a/lightpath/path.py
+++ b/lightpath/path.py
@@ -193,6 +193,9 @@ class BeamPath(OphydObject):
         super().__init__(name=name)
         self.minimum_transmission = minimum_transmission
         self.devices = devices
+        if len(self.devices) < 1:
+            raise ValueError('BeamPath must have at least one device')
+
         self._has_subscribed = False
         self.branch_list = set()
         logger.debug("Configuring path %s with %s devices",

--- a/lightpath/tests/test_controller.py
+++ b/lightpath/tests/test_controller.py
@@ -4,6 +4,7 @@ import happi
 import pytest
 
 from lightpath import LightController
+from lightpath.errors import PathError
 
 
 def test_controller_paths(lcls_client: happi.Client):
@@ -170,5 +171,6 @@ def test_cfg_loading(lcls_client: happi.Client, cfg: Dict[str, Any]):
         'beamlines': {'NOT': ['NO_BR']},
         'hutches': ['NOT']
     }
-    with pytest.raises(ValueError):
-        _ = LightController(lcls_client, cfg=bad_cfg)
+    with pytest.raises(PathError):
+        bad_lc = LightController(lcls_client, cfg=bad_cfg)
+        bad_lc.active_path('NOT')

--- a/lightpath/tests/test_controller.py
+++ b/lightpath/tests/test_controller.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict
 
 import happi
+import pytest
 
 from lightpath import LightController
 
@@ -163,3 +164,11 @@ def test_cfg_loading(lcls_client: happi.Client, cfg: Dict[str, Any]):
     assert lc.active_path('XCS').minimum_transmission == cfg['min_trans']
     assert lc.active_path('TMO').minimum_transmission == cfg['min_trans']
     assert lc.active_path('XPP').minimum_transmission == cfg['min_trans']
+
+    # test cfg settings that don't have matching devices
+    bad_cfg = {
+        'beamlines': {'NOT': ['NO_BR']},
+        'hutches': ['NOT']
+    }
+    with pytest.raises(ValueError):
+        _ = LightController(lcls_client, cfg=bad_cfg)


### PR DESCRIPTION
## Description
`LightController.load_beamlines` was mistakenly still referencing the built-in `beamlines` config/dictionary, despite the config being updated at `__init__`.  

https://github.com/pcdshub/lightpath/blob/09be87d335952d39a597f2fe8bb1576bd8f2ece3/lightpath/controller.py#L147

This did not show up as a bug because subsequent paths to `LightController.get_paths` did this correctly, and as long as the graph was initialized (using `load_beamlines`) to have the required paths, `get_paths` would find the path and split it according to the new (provided) cfg

https://github.com/pcdshub/lightpath/blob/09be87d335952d39a597f2fe8bb1576bd8f2ece3/lightpath/controller.py#L192

https://github.com/pcdshub/lightpath/blob/09be87d335952d39a597f2fe8bb1576bd8f2ece3/lightpath/controller.py#L212

Where the bug appears is if you create a config with beamlines/sources not present in the default config.  In this case, the graph would not be initialized correctly, and the `get_paths` call would fail to find a path through the graph

(Also slips in an actual error message for when there are no devices found in a branch)

## Motivation and Context
In fixing up the hutch-python usage of lightpath, I tried testing with arbitrary beamlines/branch names and stumbled upon this.

## How Has This Been Tested?
Interactively.  
I should add a test.

## Where Has This Been Documented?
This PR