### PR TITLE
BLD: vendor AggregateSignal

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -21,7 +21,6 @@ requirements:
     - happi >=1.6.0
     - numpy
     - ophyd
-    - pcdsdevices >=3.4.0
     - prettytable
     - pydm
     - pyqt >=5,<5.15

--- a/docs/source/upcoming_release_notes/173-bld_rm_pcdsdev_dep.rst
+++ b/docs/source/upcoming_release_notes/173-bld_rm_pcdsdev_dep.rst
@@ -1,0 +1,22 @@
+173 bld_rm_pcdsdev_dep
+######################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- Prevents cli entrypoint from returning the LightApp instance.
+
+Maintenance
+-----------
+- Removes pcdsdevices dependency by vendoring AggregateSignal.
+
+Contributors
+------------
+- tangkong

--- a/lightpath/main.py
+++ b/lightpath/main.py
@@ -102,9 +102,8 @@ def main(
     lp = LightApp(lc)
     # Execute
     lp.show()
-    app.exec_()
-
-    return lp
+    exit_code = app.exec_()
+    return exit_code
 
 
 def entrypoint():
@@ -127,4 +126,4 @@ def entrypoint():
     level = 'DEBUG' if args.debug else 'INFO'
     coloredlogs.install(level=level, logger=logger,
                         fmt='[%(asctime)s] - %(levelname)s -  %(message)s')
-    main(args.db, hutches, args.cfg)
+    return main(args.db, hutches, args.cfg)

--- a/lightpath/main.py
+++ b/lightpath/main.py
@@ -127,4 +127,4 @@ def entrypoint():
     level = 'DEBUG' if args.debug else 'INFO'
     coloredlogs.install(level=level, logger=logger,
                         fmt='[%(asctime)s] - %(levelname)s -  %(message)s')
-    return main(args.db, hutches, args.cfg)
+    main(args.db, hutches, args.cfg)

--- a/lightpath/mock_devices.py
+++ b/lightpath/mock_devices.py
@@ -1,17 +1,333 @@
+import contextlib
+import dataclasses
+from threading import RLock
 from types import SimpleNamespace
+from typing import Dict, Generator, Optional, Union
 
+import numpy.typing as npt
+import ophyd
 from ophyd import Component as Cpt
 from ophyd import Device, Kind, Signal
 from ophyd.status import DeviceStatus
 from ophyd.utils import DisconnectedError
-from pcdsdevices.signal import AggregateSignal
 
 from .path import LightpathState
-
 
 #####################
 # Simulated Classes #
 #####################
+OphydBaseType = Union[
+    str,
+    int,
+    bool,
+    float,
+]
+OphydDataType = Union[
+    OphydBaseType,
+    list[OphydBaseType],
+    npt.NDArray[OphydBaseType]
+]
+
+
+@dataclasses.dataclass
+class _AggregateSignalState:
+    """
+    This class holds per-Signal state information when used as part of an
+    AggregateSignal.
+
+    It includes a cache of the last value, connectivity status, and callback
+    identifiers from ophyd.
+    """
+    #: The signal itself
+    signal: Signal
+    #: Is the signal connected according to its metadata callback?
+    connected: bool = False
+    #: The last value retrieved from a value callback, or a direct get request.
+    value: Optional[OphydDataType] = None
+    #: The value subscription callback ID (None if not yet subscribed)
+    value_cbid: Optional[int] = None
+    #: The meta subscription callback ID (None if not yet subscribed)
+    meta_cbid: Optional[int] = None
+
+
+class AggregateSignal(Signal):
+    """
+    Signal that is composed of a number of other signals.
+
+    This class exists to handle the group subscriptions without repeatedly
+    getting the values of all the subsignals at all times.
+
+    This signal type is intended to be used programmatically with a subclass.
+    For simple per-device usage, see :class:`MultiDerivedSignal`.
+    """
+
+    _update_only_on_change: bool = True
+    _has_subscribed: bool
+    _signals: Dict[Signal, _AggregateSignalState]
+
+    def __init__(self, *, name, value=None, **kwargs):
+        super().__init__(name=name, value=value, **kwargs)
+        self._has_subscribed = False
+        self._lock = RLock()
+        self._signals = {}
+
+    def _calc_readback(self):
+        """
+        Override this with a calculation to find the current state given the
+        cached values.
+
+        Returns
+        -------
+        readback
+            The result of the calculation.
+        """
+
+        raise NotImplementedError(
+            'Subclasses must implement _calc_readback'
+        )  # pragma nocover
+
+    def _insert_value(self, signal, value):
+        """Update the cache with one value and recalculate."""
+        with self._lock:
+            self._signals[signal].value = value
+            self._update_readback()
+            return self._readback
+
+    @property
+    def _have_values(self) -> bool:
+        """Is the value cache populated?"""
+        return all(
+            siginfo.value is not None for siginfo in self._signals.values()
+        )
+
+    def _update_readback(self) -> Optional[OphydDataType]:
+        """
+        Recalculate the readback value.
+
+        Requires that the signal info cache has been updated prior to the
+        call.  This information could be sourced via subscriptions or manually
+        queried updates as in ``.get()``.
+
+        Returns
+        -------
+        value : OphydDataType or None
+            This is the newly-calculated value, if available. If there are
+            missing values in the cache, the previously-calculated readback
+            value (or the default passed into the ``Signal`` instance or
+            ``None``) will be returned.
+        """
+        with self._lock:
+            if self._have_values:
+                self._readback = self._calc_readback()
+            return self._readback
+
+    def get(self, **kwargs):
+        """
+        Update all values and recalculate.
+
+        Parameters
+        ----------
+        **kwargs :
+            Keyword arguments are passed to each ``signal.get(**kwargs)``.
+        """
+        with self._lock:
+            for signal, siginfo in self._signals.items():
+                siginfo.value = signal.get(**kwargs)
+            return self._update_readback()
+
+    def put(self, value, **kwargs):
+        raise NotImplementedError(
+            'put should be overridden in a subclass'
+        )  # pragma nocover
+
+    def subscribe(self, cb, event_type=None, run=True):
+        cid = super().subscribe(cb, event_type=event_type, run=run)
+        recognized_event = event_type in (None, self.SUB_VALUE, self.SUB_META)
+        if recognized_event and not self._has_subscribed:
+            self._setup_subscriptions()
+
+        return cid
+
+    subscribe.__doc__ = ophyd.ophydobj.OphydObject.subscribe.__doc__
+
+    def _setup_subscriptions(self):
+        """Subscribe to all relevant signals."""
+        with self._lock:
+            if self._has_subscribed:
+                return
+
+            self._has_subscribed = True
+
+        try:
+            for signal, siginfo in self._signals.items():
+                self.log.debug("Subscribing %s", signal.name)
+                if siginfo.value_cbid is not None:
+                    # Only subscribe once.
+                    continue
+
+                siginfo.meta_cbid = signal.subscribe(
+                    self._signal_meta_callback,
+                    run=True,
+                    event_type=signal.SUB_META,
+                )
+                siginfo.value_cbid = signal.subscribe(
+                    self._signal_value_callback,
+                    run=True,
+                )
+        except Exception:
+            self.log.exception("Failed to subscribe to signals")
+
+    def wait_for_connection(self, *args, **kwargs):
+        """Wait for underlying signals to connect."""
+        self._setup_subscriptions()
+        return super().wait_for_connection(*args, **kwargs)
+
+    def _signal_meta_callback(
+        self, *, connected: bool = False, obj: Signal, **kwargs
+    ) -> None:
+        """This is a SUB_META callback from one of the aggregated signals."""
+        with self._check_connectivity():
+            self._signals[obj].connected = connected
+
+    def _signal_value_callback(self, *, obj: Signal, **kwargs):
+        """This is a SUB_VALUE callback from one of the aggregated signals."""
+        kwargs.pop('sub_type')
+        kwargs.pop('old_value')
+        value = kwargs['value']
+        with self._lock:
+            old_value = self._readback
+            # Update just one value and assume the rest are cached
+            # This allows us to run subs without EPICS gets
+            # Run metadata callbacks before the value callback, if appropriate
+            with self._check_connectivity() as connectivity_info:
+                value = self._insert_value(obj, value)
+            if connectivity_info["sent_value_callback"]:
+                # Avoid sending a duplicate SUB_VALUE event since the
+                # connectivity check above did it already
+                return
+            if value != old_value or not self._update_only_on_change:
+                self._run_subs(sub_type=self.SUB_VALUE, obj=self, value=value,
+                               old_value=old_value)
+
+    @property
+    def connected(self) -> bool:
+        """Are all relevant signals connected?"""
+        if self._destroyed:
+            return False
+
+        if self._has_subscribed:
+            return all(
+                siginfo.connected and siginfo.value is not None
+                for siginfo in self._signals.values()
+            )
+
+        # Only check connectivity status of the signal; cross fingers that it
+        # reflects both being connected and having a not-None value.
+        return all(signal.connected for signal in self._signals)
+
+    @contextlib.contextmanager
+    def _check_connectivity(self) -> Generator[Dict[str, bool], None, None]:
+        """
+        Context manager for checking connectivity.
+
+        The block for the context manager should perform some operation
+        to change the state of the signal.
+
+        Returns state information as a dictionary, accessible after the
+        context manager block has finished evaluation.
+        """
+        was_connected = self.connected
+        state_info = {
+            "was_connected": was_connected,
+            "is_connected": was_connected,
+            "sent_md_callback": False,
+            "sent_value_callback": False,
+        }
+
+        yield state_info
+
+        # Now that the caller has updated state, check to see if our
+        # connectivity status has changed.  Update the mutable return
+        # value at this point.
+        is_connected = self.connected
+        state_info["is_connected"] = is_connected
+        if was_connected != is_connected:
+            self._metadata["connected"] = is_connected
+            self._run_metadata_callbacks()
+            state_info["sent_md_callback"] = True
+
+        if not was_connected and is_connected:
+            # disconnected -> connected; give a proper value callback.
+            # "connected" indicates that:
+            # 1. All underlying signals are connected
+            # 2. All underlying signals have a value cached
+            with self._lock:
+                old_value = self._readback
+                self._readback = self._calc_readback()
+                self._run_subs(
+                    sub_type=self.SUB_VALUE,
+                    obj=self,
+                    value=self._readback,
+                    old_value=old_value,
+                )
+                state_info["sent_value_callback"] = True
+
+    def add_signal_by_attr_name(self, name: str) -> Signal:
+        """
+        Add a signal from which to aggregate information.
+
+        This must be called before any subscriptions are made to the signal.
+        Duplicate signals will not be re-added.
+
+        Parameters
+        ----------
+        name : str
+            The attribute name of the signal, relative to the parent device.
+
+        Returns
+        -------
+        sig : ophyd.Signal
+            The signal referenced by the attribute name.
+
+        Raises
+        ------
+        RuntimError
+            If called after .subscribe() or used without a parent Device.
+        """
+        if self._has_subscribed:
+            raise RuntimeError(
+                "Cannot add signals to an AggregateSignal after it has been "
+                "subscribed to."
+            )
+
+        sig = self.parent
+
+        if sig is None:
+            raise RuntimeError(
+                "Cannot use an AggregateSignal with attribute names outside "
+                "of a Device/Component hierarchy."
+            )
+
+        for part in name.split('.'):
+            sig = getattr(sig, part)
+
+        # Add if not yet there; but do not subscribe just yet.
+        self._signals[sig] = _AggregateSignalState(signal=sig)
+        return sig
+
+    def destroy(self):
+        for signal, info in self._signals.items():
+            if info.value_cbid is not None:
+                signal.unsubscribe(info.value_cbid)
+                info.value_cbid = None
+
+            if info.meta_cbid is not None:
+                signal.unsubscribe(info.meta_cbid)
+                info.meta_cbid = None
+
+        return super().destroy()
+
+
 class SummarySignal(AggregateSignal):
     """
     Signal that holds a hash of the values of the constituent signals.

--- a/lightpath/tests/test_cli.py
+++ b/lightpath/tests/test_cli.py
@@ -2,6 +2,7 @@ import os
 from pathlib import Path
 from typing import Any, Dict, List
 
+import ophyd
 import pydm
 import pytest
 from qtpy.QtWidgets import QApplication
@@ -19,7 +20,17 @@ def no_gui_launch(monkeypatch):
         pass
 
     monkeypatch.setattr(QApplication, 'exec_', no_op)
+    monkeypatch.setattr(QApplication, 'exit', no_op)
     monkeypatch.setattr(pydm.Display, 'show', no_op)
+
+    # also prevent changing of tiemout
+    monkeypatch.setattr(ophyd.signal.EpicsSignalBase, 'set_defaults', no_op)
+
+
+def ophyd_cleanup():
+    dispatcher = ophyd.cl.get_dispatcher()
+    if dispatcher is not None:
+        dispatcher.stop()
 
 
 @pytest.fixture(scope='session')
@@ -41,42 +52,29 @@ def sim_cfg_path(tmp_path_factory):
 
 @pytest.fixture(scope='function')
 def launch_cli(qtbot, no_gui_launch, sim_cfg_path: Path):
+
     def starter(args: List[str]) -> LightApp:
         """ Launches the gui with the given args, filling cfg if needed """
         if '--cfg' in args:
             args.append(str(sim_cfg_path))
 
         with cli_args(args):
-            lp = entrypoint()
-        qtbot.addWidget(lp)
-        return lp
+            entrypoint()
 
     return starter
 
 
-def test_cli_cfg(launch_cli, cfg: Dict[str, Any]):
+def test_cli_no_arg_smoke(launch_cli):
     # smoke test
-    lp = launch_cli(['lightpath', '--cfg'])
-
-    lines = set([lp.destination_combo.itemText(i)
-                 for i in range(lp.destination_combo.count())])
-    assert lines == set(cfg['hutches'])
-    lp.close()
+    launch_cli(['lightpath'])
+    ophyd_cleanup()
 
 
-def test_cli_no_args(launch_cli):
-    lp = launch_cli(['lightpath', '--sim'])
-
-    assert lp.destination_combo.count() == 9
-
-    lp.close()
+def test_cli_no_args_smoke(launch_cli):
+    launch_cli(['lightpath', '--sim'])
+    ophyd_cleanup()
 
 
-def test_cli_hutch_cfg(launch_cli, cfg: Dict[str, Any]):
-    lp = launch_cli(['lightpath', '--hutches', 'XCS', '--cfg'])
-
-    # cfg overrides hutches setting
-    assert lp.destination_combo.count() == len(cfg['hutches'])
-    assert lp.path.minimum_transmission == cfg['min_trans']
-
-    lp.close()
+def test_cli_hutch_cfg_smoke(launch_cli, cfg: Dict[str, Any]):
+    launch_cli(['lightpath', '--hutches', 'XCS', '--cfg'])
+    ophyd_cleanup()

--- a/lightpath/tests/test_cli.py
+++ b/lightpath/tests/test_cli.py
@@ -27,12 +27,6 @@ def no_gui_launch(monkeypatch):
     monkeypatch.setattr(ophyd.signal.EpicsSignalBase, 'set_defaults', no_op)
 
 
-def ophyd_cleanup():
-    dispatcher = ophyd.cl.get_dispatcher()
-    if dispatcher is not None:
-        dispatcher.stop()
-
-
 @pytest.fixture(scope='session')
 def sim_cfg_path(tmp_path_factory):
     cfg_path = os.path.join(os.path.dirname(__file__), 'conf.yml')
@@ -64,17 +58,9 @@ def launch_cli(qtbot, no_gui_launch, sim_cfg_path: Path):
     return starter
 
 
-def test_cli_no_arg_smoke(launch_cli):
-    # smoke test
-    launch_cli(['lightpath'])
-    ophyd_cleanup()
-
-
 def test_cli_no_args_smoke(launch_cli):
     launch_cli(['lightpath', '--sim'])
-    ophyd_cleanup()
 
 
 def test_cli_hutch_cfg_smoke(launch_cli, cfg: Dict[str, Any]):
     launch_cli(['lightpath', '--hutches', 'XCS', '--cfg'])
-    ophyd_cleanup()

--- a/lightpath/tests/test_controller.py
+++ b/lightpath/tests/test_controller.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Any, Dict
 
 import happi
@@ -174,3 +175,15 @@ def test_cfg_loading(lcls_client: happi.Client, cfg: Dict[str, Any]):
     with pytest.raises(PathError):
         bad_lc = LightController(lcls_client, cfg=bad_cfg)
         bad_lc.active_path('NOT')
+
+
+def test_sim_ctrl():
+    # make sure sim beamline loads
+    sim_db_path = Path(__file__).parent / 'path.json'
+    sim_client = happi.Client(path=sim_db_path)
+
+    lc = LightController(sim_client)
+
+    assert len(lc.beamlines.keys()) == 9
+    assert len(lc.active_path('XCS').devices) == 13
+    assert lc.get_device('sl2k0')

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ coloredlogs
 happi>=1.6.0
 numpy
 ophyd
-pcdsdevices>=3.4.0
 prettytable
 pydm
 PyQt5<5.15.0


### PR DESCRIPTION
## Description
Vendor `AggregateSignal` from `pcdsdevices` to remove pcdsdevices build dependency

## Motivation and Context
We should remove circular dependencies

Issues encountered while playing test-suite-whackamole:
- ophyd cleanup via `ophyd.cl.dispatcher.stop()` seemed to break later tests, which do not restore this cl.  There was error spam that led to its initial inclusion, but removing the no-arg test fixes that (I think)
- the no-arg test would try to pull a HAPPI_CFG, which doesn't exist in CI and is functionality possibly better tested in happi than lightpath
- locally, many intermittent failures were fixed by the inclusion of `time.sleep` calls after changing signals, presumably to allow callbacks to process and `LightApp` to update.  These delays were arbitrary and the test suite passed here, so I haven't included them.  (This also doesn't address the pcds-envs issues zach found, which I haven't been able to replicate)
- EPICS got mad at the test suite trying to repeatedly change the EpicsSignal timeout, so I monkeypatched it in the test suite

## How Has This Been Tested?
test suite

## Where Has This Been Documented?
This PR
