### PR TITLE
MNT: split XPP into XPP-PINK and XPP-MONO

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -37,6 +37,11 @@ requirements:
 test:
   imports:
     - lightpath
+  requires:
+    - ipython
+    - matplotlib
+    - pytest <7.2.0
+    - pytest-qt
 
 about:
   home: https://github.com/pcdshub/lightpath

--- a/docs/source/upcoming_release_notes/176-mnt_split_xpp.rst
+++ b/docs/source/upcoming_release_notes/176-mnt_split_xpp.rst
@@ -1,0 +1,22 @@
+176 mnt_split_xpp
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- filters the visible LightRow widgets after a path change. This fixes a bug where changing paths would show all devices on a path, ignoring the state of show-removed or device filter checkboxes.
+
+Maintenance
+-----------
+- Splits the XPP line into 'XPP_PINK' and 'XPP_MONO' so both are visible and selectable.  This schange only affects the default config file; the ability to specify multiple paths or endpoints for a single name in the config remains.
+
+Contributors
+------------
+- tangkong

--- a/docs/source/upcoming_release_notes/176-mnt_split_xpp.rst
+++ b/docs/source/upcoming_release_notes/176-mnt_split_xpp.rst
@@ -15,7 +15,7 @@ Bugfixes
 
 Maintenance
 -----------
-- Splits the XPP line into 'XPP_PINK' and 'XPP_MONO' so both are visible and selectable.  This schange only affects the default config file; the ability to specify multiple paths or endpoints for a single name in the config remains.
+- Splits the XPP line into 'XPP_PINK' and 'XPP_MONO' so both are visible and selectable.  This change only affects the default config file; the ability to specify multiple paths or endpoints for a single name in the config remains.
 
 Contributors
 ------------

--- a/docs/source/upcoming_release_notes/176-mnt_split_xpp.rst
+++ b/docs/source/upcoming_release_notes/176-mnt_split_xpp.rst
@@ -16,6 +16,7 @@ Bugfixes
 Maintenance
 -----------
 - Splits the XPP line into 'XPP_PINK' and 'XPP_MONO' so both are visible and selectable.  This change only affects the default config file; the ability to specify multiple paths or endpoints for a single name in the config remains.
+- Copies test requirements into the conda recipe
 
 Contributors
 ------------

--- a/lightpath/config.py
+++ b/lightpath/config.py
@@ -5,7 +5,8 @@ Configuration for LCLS beamlines
 # mapping of endstation to either:
 # - a list of branch names
 # - a mapping of branch names to final z position
-beamlines = {'XPP': {'L0': 800, 'L2': None},
+beamlines = {'XPP_PINK': {'L0': 800},
+             'XPP_MONO': ['L2'],
              'XCS': ['L3'],
              'MFX': ['L5'],
              'CXI': ['L0'],

--- a/lightpath/tests/test_controller.py
+++ b/lightpath/tests/test_controller.py
@@ -9,8 +9,9 @@ from lightpath.errors import PathError
 
 
 def test_controller_paths(lcls_client: happi.Client):
-    beamlines = {'XPP': 8, 'XCS': 13, 'MFX': 14, 'CXI': 15, 'MEC': 14,
-                 'TMO': 12, 'CRIX': 11, 'QRIX': 11, 'TXI': 5}
+    beamlines = {'XPP_PINK': 8, 'XPP_MONO': 11, 'XCS': 13, 'MFX': 14,
+                 'CXI': 15, 'MEC': 14, 'TMO': 12, 'CRIX': 11, 'QRIX': 11,
+                 'TXI': 5}
 
     # load controller with all beamlines + invalid ones
     controller = LightController(lcls_client,
@@ -25,14 +26,15 @@ def test_controller_paths(lcls_client: happi.Client):
 
     # Range of each path is correct
     # all HXR lines share a beginning
-    for line in ['XPP', 'XCS', 'MFX', 'CXI', 'MEC']:
+    for line in ['XPP_PINK', 'XPP_MONO', 'XCS', 'MFX', 'CXI', 'MEC']:
         assert controller.active_path(line).path[0].name == 'im1l0'
     # all SXR lines share a beginning
     for line in ['TMO', 'CRIX', 'QRIX']:
         assert controller.active_path(line).path[0].name == 'im1k0'
     # TXI omitted, doesn't work yet
 
-    assert controller.active_path('XPP').path[-1].name == 'xpp_lodcm'
+    assert controller.active_path('XPP_PINK').path[-1].name == 'xpp_lodcm'
+    assert controller.active_path('XPP_MONO').path[-1].name == 'im2l2'
     assert controller.active_path('XCS').path[-1].name == 'im2l3'
     assert controller.active_path('MFX').path[-1].name == 'im2l5'
     assert controller.active_path('CXI').path[-1].name == 'im6l0'
@@ -184,6 +186,6 @@ def test_sim_ctrl():
 
     lc = LightController(sim_client)
 
-    assert len(lc.beamlines.keys()) == 9
+    assert len(lc.beamlines.keys()) == 10
     assert len(lc.active_path('XCS').devices) == 13
     assert lc.get_device('sl2k0')

--- a/lightpath/tests/test_gui.py
+++ b/lightpath/tests/test_gui.py
@@ -69,7 +69,7 @@ def test_upstream_check(lightapp: LightApp, monkeypatch):
 
 
 def test_filtering(lightapp: LightApp, monkeypatch):
-    lightapp.destination_combo.setCurrentIndex(4)  # set current to MEC
+    lightapp.destination_combo.setCurrentIndex(5)  # set current to MEC
     # Create mock functions
     for row in lightapp.rows:
         monkeypatch.setattr(row[0], 'setHidden', Mock())

--- a/lightpath/tests/test_path.py
+++ b/lightpath/tests/test_path.py
@@ -1,5 +1,6 @@
 import io
 import re
+import time
 from unittest.mock import Mock
 
 from ophyd.device import Device
@@ -203,6 +204,7 @@ def test_callback(path: BeamPath):
     path.subscribe(cb, run=False)
     # Change state of beampath
     path.devices[4].insert()
+    time.sleep(0.2)
     # Assert callback has been run
     assert cb.called
 

--- a/lightpath/ui/gui.py
+++ b/lightpath/ui/gui.py
@@ -376,10 +376,6 @@ class LightApp(Display):
             # "upstream" devices now.  Possibly by branch name?
             hidden_upstream = (device.md.z < upstream_device_z)
             # Hide device if any of the criteria are met
-            if row[0].device.name == 'xcs_lodcm':
-                print('--')
-                print(not self.remove_check.isChecked(), row[0].last_state)
-                print(hidden_device_type, hidden_removed, hidden_upstream)
             row[0].setHidden(hidden_device_type
                              or hidden_removed
                              or hidden_upstream)

--- a/lightpath/ui/gui.py
+++ b/lightpath/ui/gui.py
@@ -255,6 +255,8 @@ class LightApp(Display):
         self.update_path()
         # Update device type checkboxes
         self.update_device_types()
+        # re-filter based on present settings
+        self.filter()
         self.setWindowTitle(f'Lightpath - {self.selected_beamline()}')
 
     @contextlib.contextmanager
@@ -365,7 +367,7 @@ class LightApp(Display):
             # Hide if a hidden instance of a device type
             hidden_device_type = any([device.__module__ == dtype
                                       for dtype in self.hidden_devices])
-            # Hide if removed
+            # Hide if removed (checked if showing removed devices)
             hidden_removed = (not self.remove_check.isChecked()
                               and row[0].last_state == DeviceState.Removed)
             # Hide if upstream
@@ -374,6 +376,10 @@ class LightApp(Display):
             # "upstream" devices now.  Possibly by branch name?
             hidden_upstream = (device.md.z < upstream_device_z)
             # Hide device if any of the criteria are met
+            if row[0].device.name == 'xcs_lodcm':
+                print('--')
+                print(not self.remove_check.isChecked(), row[0].last_state)
+                print(hidden_device_type, hidden_removed, hidden_upstream)
             row[0].setHidden(hidden_device_type
                              or hidden_removed
                              or hidden_upstream)


### PR DESCRIPTION
## Description
Splits XPP's single entry in the default config into two: `XPP_MONO` and `XPP_PINK`.  
Fixes the test suite accordingly
Fixes a small bug on the way that didn't re-filter the visible devices after changing a path.

## Motivation and Context
All caps because of some `string.upper()` stuff we do in the GUI.

Previously XPP would have two possible beampaths splitting at the xpp lodcm.  One going on the L0 branch and one on the L2 branch.  While before we were letting lightpath choose which branch is active (by whichever branch has the sees beam at the highest z), it became clear that XPP would want to see the status of either line independently.  

The test_path/test_callback test failed again, but passed after a re-run. I tried adding in a sleep clause to possibly let it process, but the failures are intermittent enough that it'll be tough to nail down.  This is not the only test that might benefit from this kind of pause, as many other tests invoke similar code paths.  

Perhaps we just resign ourselves to re-running test jobs.  At least GHA shows past results from re-run jobs

## How Has This Been Tested?
Interactively.

## Where Has This Been Documented?
This PR, and [JIRA](https://jira.slac.stanford.edu/browse/LCLSECSD-1630)