### PR TITLE
REV: revert split of xpp line

### DIFF
--- a/docs/source/upcoming_release_notes/176-mnt_split_xpp.rst
+++ b/docs/source/upcoming_release_notes/176-mnt_split_xpp.rst
@@ -15,7 +15,6 @@ Bugfixes
 
 Maintenance
 -----------
-- Splits the XPP line into 'XPP_PINK' and 'XPP_MONO' so both are visible and selectable.  This change only affects the default config file; the ability to specify multiple paths or endpoints for a single name in the config remains.
 - Copies test requirements into the conda recipe
 
 Contributors

--- a/lightpath/config.py
+++ b/lightpath/config.py
@@ -5,8 +5,7 @@ Configuration for LCLS beamlines
 # mapping of endstation to either:
 # - a list of branch names
 # - a mapping of branch names to final z position
-beamlines = {'XPP_PINK': {'L0': 800},
-             'XPP_MONO': ['L2'],
+beamlines = {'XPP': {'L0': 800, 'L2': None},
              'XCS': ['L3'],
              'MFX': ['L5'],
              'CXI': ['L0'],

--- a/lightpath/tests/test_controller.py
+++ b/lightpath/tests/test_controller.py
@@ -9,9 +9,8 @@ from lightpath.errors import PathError
 
 
 def test_controller_paths(lcls_client: happi.Client):
-    beamlines = {'XPP_PINK': 8, 'XPP_MONO': 11, 'XCS': 13, 'MFX': 14,
-                 'CXI': 15, 'MEC': 14, 'TMO': 12, 'CRIX': 11, 'QRIX': 11,
-                 'TXI': 5}
+    beamlines = {'XPP': 8, 'XCS': 13, 'MFX': 14, 'CXI': 15, 'MEC': 14,
+                 'TMO': 12, 'CRIX': 11, 'QRIX': 11, 'TXI': 5}
 
     # load controller with all beamlines + invalid ones
     controller = LightController(lcls_client,
@@ -26,15 +25,14 @@ def test_controller_paths(lcls_client: happi.Client):
 
     # Range of each path is correct
     # all HXR lines share a beginning
-    for line in ['XPP_PINK', 'XPP_MONO', 'XCS', 'MFX', 'CXI', 'MEC']:
+    for line in ['XPP', 'XCS', 'MFX', 'CXI', 'MEC']:
         assert controller.active_path(line).path[0].name == 'im1l0'
     # all SXR lines share a beginning
     for line in ['TMO', 'CRIX', 'QRIX']:
         assert controller.active_path(line).path[0].name == 'im1k0'
     # TXI omitted, doesn't work yet
 
-    assert controller.active_path('XPP_PINK').path[-1].name == 'xpp_lodcm'
-    assert controller.active_path('XPP_MONO').path[-1].name == 'im2l2'
+    assert controller.active_path('XPP').path[-1].name == 'xpp_lodcm'
     assert controller.active_path('XCS').path[-1].name == 'im2l3'
     assert controller.active_path('MFX').path[-1].name == 'im2l5'
     assert controller.active_path('CXI').path[-1].name == 'im6l0'
@@ -186,6 +184,6 @@ def test_sim_ctrl():
 
     lc = LightController(sim_client)
 
-    assert len(lc.beamlines.keys()) == 10
+    assert len(lc.beamlines.keys()) == 9
     assert len(lc.active_path('XCS').devices) == 13
     assert lc.get_device('sl2k0')

--- a/lightpath/tests/test_gui.py
+++ b/lightpath/tests/test_gui.py
@@ -69,7 +69,7 @@ def test_upstream_check(lightapp: LightApp, monkeypatch):
 
 
 def test_filtering(lightapp: LightApp, monkeypatch):
-    lightapp.destination_combo.setCurrentIndex(5)  # set current to MEC
+    lightapp.destination_combo.setCurrentIndex(4)  # set current to MEC
     # Create mock functions
     for row in lightapp.rows:
         monkeypatch.setattr(row[0], 'setHidden', Mock())


### PR DESCRIPTION
## Description
reverts the config split of XPP into two lines for hutch-python compatibility

## Motivation and Context
Hutch-python expects very specific hutch names, so we should not change the ones that are available by default. 

This split can simply be done via custom config files in the future

Can't just revert the whole PR since there were other fixes in it

## How Has This Been Tested?
reverting and running the test suite

## Where Has This Been Documented?
This PR
