### PR TITLE
BLD: release pyqt pin

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - ophyd
     - prettytable
     - pydm
-    - pyqt >=5,<5.15
+    - pyqt >=5
     - qtawesome
     - qtpy
     - typhos >=1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ numpy
 ophyd
 prettytable
 pydm
-PyQt5<5.15.0
+PyQt5
 qtawesome
 qtpy
 typhos>=1.0.0


### PR DESCRIPTION
## Description
Try releasing the pyqt pin

## Motivation and Context
Maybe this fixes our matplotlib py3.11 issues?

## How Has This Been Tested?
may CI be graceful to us

## Where Has This Been Documented?
This PR