### PR TITLE
TST: wait for conditions during troublesome tests

### DIFF
--- a/lightpath/tests/conftest.py
+++ b/lightpath/tests/conftest.py
@@ -48,6 +48,8 @@ def wait_until(condition: callable, interval=0.1, timeout=1, *args, **kwargs):
     while not condition(*args, **kwargs) and time.time() - start < timeout:
         time.sleep(interval)
 
+    print(f'{time.time() - start:.3} s elapsed')
+
 
 # Basic Device
 @pytest.fixture(scope='function')

--- a/lightpath/tests/conftest.py
+++ b/lightpath/tests/conftest.py
@@ -1,6 +1,7 @@
 import logging
 import os.path
 import sys
+import time
 from contextlib import contextmanager
 
 import happi
@@ -42,6 +43,12 @@ def set_level(pytestconfig):
 ############
 # Fixtures #
 ############
+def wait_until(condition: callable, interval=0.1, timeout=1, *args, **kwargs):
+    start = time.time()
+    while not condition(*args, **kwargs) and time.time() - start < timeout:
+        time.sleep(interval)
+
+
 # Basic Device
 @pytest.fixture(scope='function')
 def device():

--- a/lightpath/tests/test_gui.py
+++ b/lightpath/tests/test_gui.py
@@ -2,6 +2,7 @@ from distutils.spawn import find_executable
 from unittest.mock import Mock
 
 import pytest
+from pytestqt.qtbot import QtBot
 
 from lightpath.controller import LightController
 from lightpath.ui import LightApp
@@ -68,7 +69,7 @@ def test_upstream_check(lightapp: LightApp, monkeypatch):
             row[0].setHidden.assert_called_with(False)
 
 
-def test_filtering(lightapp: LightApp, monkeypatch):
+def test_filtering(qtbot: QtBot, lightapp: LightApp, monkeypatch):
     lightapp.destination_combo.setCurrentIndex(4)  # set current to MEC
     # Create mock functions
     for row in lightapp.rows:
@@ -76,7 +77,7 @@ def test_filtering(lightapp: LightApp, monkeypatch):
     # Initialize properly with nothing hidden
     lightapp.filter()
     for row in lightapp.rows:
-        row[0].setHidden.assert_called_with(False)
+        qtbot.waitUntil(lambda: row[0].setHidden.assert_called_with(False))
     # Insert at least one device then hide
     device_row = lightapp.rows[2][0]
     device_row.device.insert()
@@ -87,27 +88,27 @@ def test_filtering(lightapp: LightApp, monkeypatch):
     lightapp.filter()
     for row in lightapp.rows:
         if row[0].device.get_lightpath_state().removed:
-            row[0].setHidden.assert_called_with(True)
+            qtbot.waitUntil(lambda: row[0].setHidden.assert_called_with(True))
         else:
-            row[0].setHidden.assert_called_with(False)
+            qtbot.waitUntil(lambda: row[0].setHidden.assert_called_with(False))
     # Hide upstream devices
     lightapp.select_devices('MEC')
     lightapp.remove_check.setChecked(True)
     lightapp.filter()
     for row in lightapp.rows:
         if row[0].device not in lightapp.light.active_path('MEC').path:
-            row[0].setHidden.assert_called_with(True)
+            qtbot.waitUntil(lambda: row[0].setHidden.assert_called_with(True))
         else:
-            row[0].setHidden.assert_called_with(False)
+            qtbot.waitUntil(lambda: row[0].setHidden.assert_called_with(False))
     # Dual hidden categories will not fight
     lightapp.remove_check.setChecked(False)
     lightapp.filter()
     for row in lightapp.rows:
         if ((row[0].device not in lightapp.light.active_path('MEC').path)
                 or (row[0].device.get_lightpath_state().removed)):
-            row[0].setHidden.assert_called_with(True)
+            qtbot.waitUntil(lambda: row[0].setHidden.assert_called_with(True))
         else:
-            row[0].setHidden.assert_called_with(False)
+            qtbot.waitUntil(lambda: row[0].setHidden.assert_called_with(False))
 
 
 def test_typhos_display(lightapp: LightApp):

--- a/lightpath/tests/test_path.py
+++ b/lightpath/tests/test_path.py
@@ -8,6 +8,7 @@ from ophyd.device import Device
 from lightpath import BeamPath
 from lightpath.mock_devices import Crystal, Status
 from lightpath.path import DeviceState, find_device_state
+from lightpath.tests.conftest import wait_until
 
 
 def raiser(*args, **kwargs):
@@ -206,6 +207,7 @@ def test_callback(path: BeamPath):
     path.devices[4].insert()
     time.sleep(0.2)
     # Assert callback has been run
+    wait_until(lambda: cb.called)
     assert cb.called
 
 

--- a/lightpath/tests/test_widgets.py
+++ b/lightpath/tests/test_widgets.py
@@ -34,7 +34,7 @@ def test_widget_updates(lightrow: LightRow, path: BeamPath):
                 in ipimb_row.state_label.styleSheet())
 
     wait_until(half_removed)
-    assert half_removed
+    assert half_removed()
 
     lightrow.device.remove()
 
@@ -43,7 +43,7 @@ def test_widget_updates(lightrow: LightRow, path: BeamPath):
                 in lightrow.state_label.styleSheet())
 
     wait_until(removed)
-    assert removed
+    assert removed()
 
     lightrow.device.insert()
 
@@ -52,7 +52,7 @@ def test_widget_updates(lightrow: LightRow, path: BeamPath):
                 in lightrow.state_label.styleSheet())
 
     wait_until(blocking)
-    assert blocking
+    assert blocking()
 
     # Check that callbacks have been called
     assert lightrow.state_label.setText.called

--- a/lightpath/tests/test_widgets.py
+++ b/lightpath/tests/test_widgets.py
@@ -4,6 +4,7 @@ import pytest
 from ophyd import Device
 
 from lightpath import BeamPath
+from lightpath.tests.conftest import wait_until
 from lightpath.ui import LightRow
 from lightpath.ui.widgets import (state_colors, symbol_for_device,
                                   to_stylesheet_color)
@@ -27,15 +28,32 @@ def test_widget_updates(lightrow: LightRow, path: BeamPath):
     ipimb.insert()
     ipimb.remove()
     ipimb.insert()
-    assert (to_stylesheet_color(state_colors['half_removed'])
-            in ipimb_row.state_label.styleSheet())
+
+    def half_removed():
+        return (to_stylesheet_color(state_colors['half_removed'])
+                in ipimb_row.state_label.styleSheet())
+
+    wait_until(half_removed)
+    assert half_removed
 
     lightrow.device.remove()
-    assert (to_stylesheet_color(state_colors['removed'])
-            in lightrow.state_label.styleSheet())
+
+    def removed():
+        return (to_stylesheet_color(state_colors['removed'])
+                in lightrow.state_label.styleSheet())
+
+    wait_until(removed)
+    assert removed
+
     lightrow.device.insert()
-    assert (to_stylesheet_color(state_colors['blocking'])
-            in lightrow.state_label.styleSheet())
+
+    def blocking():
+        return (to_stylesheet_color(state_colors['blocking'])
+                in lightrow.state_label.styleSheet())
+
+    wait_until(blocking)
+    assert blocking
+
     # Check that callbacks have been called
     assert lightrow.state_label.setText.called
 

--- a/lightpath/tests/test_widgets.py
+++ b/lightpath/tests/test_widgets.py
@@ -28,12 +28,13 @@ def test_widget_updates(lightrow: LightRow, path: BeamPath):
     ipimb.insert()
     ipimb.remove()
     ipimb.insert()
+    lightrow.device.insert()
 
     def half_removed():
         return (to_stylesheet_color(state_colors['half_removed'])
                 in ipimb_row.state_label.styleSheet())
 
-    wait_until(half_removed)
+    wait_until(half_removed, timeout=5)
     assert half_removed()
 
     lightrow.device.remove()
@@ -42,7 +43,7 @@ def test_widget_updates(lightrow: LightRow, path: BeamPath):
         return (to_stylesheet_color(state_colors['removed'])
                 in lightrow.state_label.styleSheet())
 
-    wait_until(removed)
+    wait_until(removed, timeout=5)
     assert removed()
 
     lightrow.device.insert()
@@ -51,7 +52,7 @@ def test_widget_updates(lightrow: LightRow, path: BeamPath):
         return (to_stylesheet_color(state_colors['blocking'])
                 in lightrow.state_label.styleSheet())
 
-    wait_until(blocking)
+    wait_until(blocking, timeout=5)
     assert blocking()
 
     # Check that callbacks have been called


### PR DESCRIPTION
## Description
Try to fix tests in #169.  Changes like these could be spread in many places

Basically just assert things with a timeout to give conditions the ability to settle.

## Motivation and Context
#169 , and other tests

## How Has This Been Tested?
Locally, and by hitting the GHA re-run button a bunch of times, likely

## Where Has This Been Documented?
This PR.