### PR TITLE
MNT: skip processing device if branches are not specified

### DIFF
--- a/docs/source/upcoming_release_notes/188-mnt_malformed_device_handling.rst
+++ b/docs/source/upcoming_release_notes/188-mnt_malformed_device_handling.rst
@@ -1,0 +1,24 @@
+188 mnt_malformed_device_handling
+#################################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- Remove hard failure when a lightpath-active device is malformed.  Instead of throwing an
+  exception, simply omit it from the facility graph
+- Trim beam paths before BeamPath objects are created, when device names are gathered into paths
+
+Contributors
+------------
+- tangkong

--- a/lightpath/controller.py
+++ b/lightpath/controller.py
@@ -116,10 +116,11 @@ class LightController:
             for branch_set in (res.metadata.get('input_branches', []),
                                res.metadata.get('output_branches', [])):
                 if branch_set is None:
-                    raise ValueError(
-                        f'device {res.item.name} has no branch information, '
+                    logger.warning(
+                        f'device ({res.item.name}) missing branch information, '
                         'check to make sure your happi database is '
                         'correctly implementing its container.')
+                    break
                 for branch in branch_set:
                     branch_dict.setdefault(branch, set()).add(res)
 


### PR DESCRIPTION
## Description
- Remove hard failure when branches aren't specified for a lightpath-active (lightpath=true) device.  Instead, we just ignore the device.
- Trim beamline device lists before BeamPath creation.  This allows a user to grab an accurate beam path without instantiating the devices. (as in hutch-python)
  - BeamPath.split() is thus now no longer used, but is likely a useful method for later use
## Motivation and Context
[jira (soft fail on invalid device)](https://jira.slac.stanford.edu/browse/ECS-4982)
[jira (lazy trim)](https://jira.slac.stanford.edu/browse/ECS-5048)

## How Has This Been Tested?
interactively, with test suite.  

(Testing with xpppython now)

## Where Has This Been Documented?
This PR, jira ticket