### PR TITLE
BLD: separate lightpath and lightpath[gui] subpackages

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -39,7 +39,6 @@ test:
     - lightpath
   requires:
     - ipython
-    - matplotlib
     - pytest <7.2.0
     - pytest-qt
 

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -39,7 +39,7 @@ test:
     - lightpath
   requires:
     - ipython
-    - pytest <7.2.0
+    - pytest
     - pytest-qt
 
 about:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -19,7 +19,6 @@ test:
     - lightpath
   requires:
     - ipython
-    - matplotlib
     - pytest <7.2.0
     - pytest-qt
 
@@ -37,6 +36,7 @@ outputs:
         - python >=3.6
         - coloredlogs
         - happi >=1.6.0
+        - networkx <3.3
         - numpy
         - ophyd
         - prettytable

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -27,6 +27,7 @@ outputs:
   - name: lightpath-base
     build:
       noarch: python
+      script: python -m pip install . -vv
     requirements:
       host:
         - python >=3.6

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -49,7 +49,7 @@ outputs:
         - pip
         - setuptools_scm
       run:
-        - lightpath-base
+        - {{ pin_subpackage('lightpath-base', max_pin='x.x') }}
         - pydm
         - pyqt >=5
         - qtawesome

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -5,7 +5,7 @@ load_file_regex(load_file=os.path.join(import_name, "_version.py"),
 regex_pattern=".*version = '(\S+)'").group(1) %}
 
 package:
-  name: lightpath-suite
+  name: {{ package_name }}
   version: {{ version }}
 
 source:
@@ -13,56 +13,35 @@ source:
 
 build:
   number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  build:
+    - python >=3.6
+    - pip
+    - setuptools_scm
+  run:
+    - python >=3.6
+    - coloredlogs
+    - happi >=1.6.0
+    - numpy
+    - ophyd
+    - prettytable
+    - pydm
+    - pyqt >=5
+    - qtawesome
+    - qtpy
+    - typhos >=1.0.0
 
 test:
   imports:
     - lightpath
   requires:
     - ipython
+    - matplotlib
     - pytest <7.2.0
     - pytest-qt
-
-outputs:
-  - name: lightpath-base
-    build:
-      noarch: python
-      script: python -m pip install . -vv --no-deps --no-build-isolation
-    requirements:
-      host:
-        - python >=3.9
-        - pip
-        - setuptools
-        - setuptools_scm
-      run:
-        - python >=3.9
-        - coloredlogs
-        - happi >=1.6.0
-        - ophyd
-        - prettytable
-      run_constrained:
-        - networkx <3.3  # networkx drops py3.9 support with 3.3
-        - numpy <2.0  # until upstream packages update (ophyd)
-
-  - name: lightpath
-    build:
-      noarch: python
-    requirements:
-      host:
-        - python >=3.9
-        - pip
-        - setuptools
-        - setuptools_scm
-      run:
-        - {{ pin_subpackage('lightpath-base', max_pin='x.x') }}
-        - pydm
-        - pyqt >=5
-        - qtawesome
-        - qtpy
-        - typhos >=1.0.0
-      test:
-        imports:
-          - lightpath
-
 
 about:
   home: https://github.com/pcdshub/lightpath

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -5,7 +5,7 @@ load_file_regex(load_file=os.path.join(import_name, "_version.py"),
 regex_pattern=".*version = '(\S+)'").group(1) %}
 
 package:
-  name: {{ package_name }}
+  name: lightpath-suite
   version: {{ version }}
 
 source:
@@ -26,17 +26,17 @@ outputs:
   - name: lightpath-base
     build:
       noarch: python
-      script: python -m pip install . -vv
+      script: {{ PYTHON }} -m pip install . -vv
     requirements:
       host:
-        - python >=3.6
+        - python >=3.9
         - pip
+        - setuptools
         - setuptools_scm
       run:
-        - python >=3.6
+        - python >=3.9
         - coloredlogs
         - happi >=1.6.0
-        - numpy
         - ophyd
         - prettytable
       run_constrained:
@@ -48,8 +48,9 @@ outputs:
       noarch: python
     requirements:
       host:
-        - python >=3.6
+        - python >=3.9
         - pip
+        - setuptools
         - setuptools_scm
       run:
         - {{ pin_subpackage('lightpath-base', max_pin='x.x') }}
@@ -58,6 +59,9 @@ outputs:
         - qtawesome
         - qtpy
         - typhos >=1.0.0
+      test:
+        imports:
+          - lightpath
 
 
 about:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -16,24 +16,6 @@ build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
 
-requirements:
-  build:
-    - python >=3.6
-    - pip
-    - setuptools_scm
-  run:
-    - python >=3.6
-    - coloredlogs
-    - happi >=1.6.0
-    - numpy
-    - ophyd
-    - prettytable
-    - pydm
-    - pyqt >=5
-    - qtawesome
-    - qtpy
-    - typhos >=1.0.0
-
 test:
   imports:
     - lightpath
@@ -42,6 +24,40 @@ test:
     - matplotlib
     - pytest <7.2.0
     - pytest-qt
+
+outputs:
+  - name: lightpath-base
+    build:
+      noarch: python
+    requirements:
+      host:
+        - python >=3.6
+        - pip
+        - setuptools_scm
+      run:
+        - python >=3.6
+        - coloredlogs
+        - happi >=1.6.0
+        - numpy
+        - ophyd
+        - prettytable
+
+  - name: lightpath
+    build:
+      noarch: python
+    requirements:
+      host:
+        - python >=3.6
+        - pip
+        - setuptools_scm
+      run:
+        - lightpath-base
+        - pydm
+        - pyqt >=5
+        - qtawesome
+        - qtpy
+        - typhos >=1.0.0
+
 
 about:
   home: https://github.com/pcdshub/lightpath

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -36,10 +36,12 @@ outputs:
         - python >=3.6
         - coloredlogs
         - happi >=1.6.0
-        - networkx <3.3
         - numpy
         - ophyd
         - prettytable
+      run_constrained:
+        - networkx <3.3  # networkx drops py3.9 support with 3.3
+        - numpy <2.0  # until upstream packages update (ophyd)
 
   - name: lightpath
     build:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -26,7 +26,7 @@ outputs:
   - name: lightpath-base
     build:
       noarch: python
-      script: python -m pip install . -vv -- no-deps --no-build-isolation
+      script: python -m pip install . -vv --no-deps --no-build-isolation
     requirements:
       host:
         - python >=3.9

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -26,7 +26,7 @@ outputs:
   - name: lightpath-base
     build:
       noarch: python
-      script: python -m pip install . -vv
+      script: python -m pip install . -vv -- no-deps --no-build-isolation
     requirements:
       host:
         - python >=3.9

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -13,8 +13,6 @@ source:
 
 build:
   number: 0
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
 
 test:
   imports:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -26,7 +26,7 @@ outputs:
   - name: lightpath-base
     build:
       noarch: python
-      script: {{ PYTHON }} -m pip install . -vv
+      script: python -m pip install . -vv
     requirements:
       host:
         - python >=3.9

--- a/gui-requirements.txt
+++ b/gui-requirements.txt
@@ -1,0 +1,5 @@
+pydm
+PyQt5
+qtawesome
+qtpy
+typhos>=1.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,11 +39,14 @@ file = "README.rst"
 [tool.setuptools.dynamic.dependencies]
 file = [ "requirements.txt",]
 
+[tool.setuptools.dynamic.optional-dependencies.gui]
+file = "gui-requirements.txt"
+
 [tool.setuptools.dynamic.optional-dependencies.doc]
 file = "docs-requirements.txt"
 
 [tool.setuptools.dynamic.optional-dependencies.test]
-file = "dev-requirements.txt"
+file = ["dev-requirements.txt", "gui-requirements.txt"]
 
 [tool.pytest.ini_options]
 addopts = "--cov=."

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ coloredlogs
 happi>=1.6.0
 numpy
 ophyd
+networkx<3.3
 prettytable

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,3 @@ happi>=1.6.0
 numpy
 ophyd
 prettytable
-pydm
-PyQt5
-qtawesome
-qtpy
-typhos>=1.0.0


### PR DESCRIPTION
## Description
Separates lightpath base and gui-related dependencies
- pip: `lightpath` and `lightpath[gui]`
- ~conda: `lightpath-base` and `lightpath` (includes gui)~  I could not get conda builds working, we leave this split to the conda feedstock

## Motivation and Context
Lightpath keeps dragging qt dependencies along with it

## How Has This Been Tested?
pip installs locally.  Conda eventually, but let's see if CI takes

## Where Has This Been Documented?
This PR