### PR TITLE
ENH: add generic rix beamline config

### DIFF
--- a/docs/source/upcoming_release_notes/191-enh_add_generic_rix.rst
+++ b/docs/source/upcoming_release_notes/191-enh_add_generic_rix.rst
@@ -1,0 +1,24 @@
+191 enh_add_generic_rix
+#######################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- Add "RIX" beamline to load all "RIX" beamline devices.
+  This is used in the rix3 hutch-python session to control
+  any of the beamline devices.
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz

--- a/lightpath/config.py
+++ b/lightpath/config.py
@@ -11,6 +11,7 @@ beamlines = {'XPP': {'L0': 800, 'L2': None},
              'CXI': ['L0'],
              'MEC': ['L4'],
              'TMO': ['K4'],
+             'RIX': ['K1', 'K2'],
              'CRIX': ['K1'],
              'QRIX': ['K2'],
              'TXI': ['K3', 'L1']}

--- a/lightpath/tests/test_controller.py
+++ b/lightpath/tests/test_controller.py
@@ -5,6 +5,7 @@ import happi
 import pytest
 
 from lightpath import LightController
+from lightpath.config import beamlines
 from lightpath.errors import PathError
 
 
@@ -184,6 +185,6 @@ def test_sim_ctrl():
 
     lc = LightController(sim_client)
 
-    assert len(lc.beamlines.keys()) == 9
+    assert len(lc.beamlines.keys()) == len(beamlines)
     assert len(lc.active_path('XCS').devices) == 13
     assert lc.get_device('sl2k0')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Add a "RIX" beamline config that spans K1 and K2, as a counterpart for the CRIX and QRIX configs.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is a rix3 hutch-python hotfix verbatim as part of https://jira.slac.stanford.edu/browse/ECS-6333

The point is so that there is a beamline called "RIX" to search for devices on when loading hutch-python.
This beamline ends up having all of the shared RIX devices.

Possibly in the future this would be removed if the rix3 hutch-python was split into crix3 and qrix3 but the way all of this works is unclear to me.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively in rix3 for a year+

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Here only.

<!--
## Screenshots (if appropriate):
-->
