### PR TITLE
TST: Work to de-flake tests

### DIFF
--- a/docs/source/upcoming_release_notes/193-tst_no_flaky.rst
+++ b/docs/source/upcoming_release_notes/193-tst_no_flaky.rst
@@ -1,0 +1,22 @@
+193 tst_no_flaky
+################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- Fix a couple tests to improve reproducibility
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tangkong

--- a/lightpath/tests/test_gui.py
+++ b/lightpath/tests/test_gui.py
@@ -5,6 +5,7 @@ import pytest
 from pytestqt.qtbot import QtBot
 
 from lightpath.controller import LightController
+from lightpath.path import DeviceState
 from lightpath.ui import LightApp
 
 
@@ -81,7 +82,11 @@ def test_filtering(qtbot: QtBot, lightapp: LightApp, monkeypatch):
     # Insert at least one device then hide
     device_row = lightapp.rows[2][0]
     device_row.device.insert()
+    for row in lightapp.rows:
+        qtbot.waitUntil(lambda: row[0].last_state is not DeviceState.Disconnected)
+
     lightapp.remove_check.setChecked(False)
+    qtbot.waitUntil(lambda: not lightapp.remove_check.isChecked())
     # Reset mock
     for row in lightapp.rows:
         row[0].setHidden.reset_mock()

--- a/lightpath/tests/test_widgets.py
+++ b/lightpath/tests/test_widgets.py
@@ -32,10 +32,9 @@ def test_widget_updates(lightrow: LightRow, path: BeamPath, qtbot: QtBot):
     ipimb.remove()
     ipimb.insert()
 
-    # Valve3 (lightrow) and ipimb5 both inserted
-    # minimum transmission = 0.1, fully blocked by valve3
+    # ipimb5, valve10 both inserted
+    # minimum transmission = 0.1, fully blocked by valve10, partially by ipimb5
 
-    # expecting the device updated callback to trigger update in ipimb_row
     # half-removed == inserted but not in blocking devices
     def half_removed():
         return (to_stylesheet_color(state_colors['half_removed'])
@@ -48,6 +47,7 @@ def test_widget_updates(lightrow: LightRow, path: BeamPath, qtbot: QtBot):
                 in valve10_row.state_label.styleSheet())
     qtbot.waitUntil(valve10_blocking, timeout=5)
 
+    # valve3 (lightrow) upstream of all devices, fully blocks
     lightrow.device.remove()
 
     def removed():

--- a/lightpath/tests/test_widgets.py
+++ b/lightpath/tests/test_widgets.py
@@ -2,16 +2,16 @@ from unittest.mock import Mock
 
 import pytest
 from ophyd import Device
+from pytestqt.qtbot import QtBot
 
 from lightpath import BeamPath
-from lightpath.tests.conftest import wait_until
 from lightpath.ui import LightRow
 from lightpath.ui.widgets import (state_colors, symbol_for_device,
                                   to_stylesheet_color)
 
 
 @pytest.fixture(scope='function')
-def lightrow(path: BeamPath, qtbot):
+def lightrow(path: BeamPath, qtbot: QtBot):
     # Generate lightpath
     w = LightRow(path.path[3], path)
     qtbot.addWidget(w)
@@ -20,22 +20,33 @@ def lightrow(path: BeamPath, qtbot):
     return w
 
 
-def test_widget_updates(lightrow: LightRow, path: BeamPath):
+def test_widget_updates(lightrow: LightRow, path: BeamPath, qtbot: QtBot):
     # inserted device may still permit beam
     ipimb = path.path[5]
     ipimb_row = LightRow(ipimb, path)
+    # Insert valve downstream of ipimb
+    valve10_row = LightRow(path.path[10], path)
+    valve10_row.device.insert()
     # Toggle device to trigger callbacks
     ipimb.insert()
     ipimb.remove()
     ipimb.insert()
-    lightrow.device.insert()
 
+    # Valve3 (lightrow) and ipimb5 both inserted
+    # minimum transmission = 0.1, fully blocked by valve3
+
+    # expecting the device updated callback to trigger update in ipimb_row
+    # half-removed == inserted but not in blocking devices
     def half_removed():
         return (to_stylesheet_color(state_colors['half_removed'])
                 in ipimb_row.state_label.styleSheet())
 
-    wait_until(half_removed, timeout=5)
-    assert half_removed()
+    qtbot.waitUntil(half_removed, timeout=5)
+
+    def valve10_blocking():
+        return (to_stylesheet_color(state_colors['blocking'])
+                in valve10_row.state_label.styleSheet())
+    qtbot.waitUntil(valve10_blocking, timeout=5)
 
     lightrow.device.remove()
 
@@ -43,8 +54,7 @@ def test_widget_updates(lightrow: LightRow, path: BeamPath):
         return (to_stylesheet_color(state_colors['removed'])
                 in lightrow.state_label.styleSheet())
 
-    wait_until(removed, timeout=5)
-    assert removed()
+    qtbot.waitUntil(removed, timeout=5)
 
     lightrow.device.insert()
 
@@ -52,8 +62,7 @@ def test_widget_updates(lightrow: LightRow, path: BeamPath):
         return (to_stylesheet_color(state_colors['blocking'])
                 in lightrow.state_label.styleSheet())
 
-    wait_until(blocking, timeout=5)
-    assert blocking()
+    qtbot.waitUntil(blocking, timeout=5)
 
     # Check that callbacks have been called
     assert lightrow.state_label.setText.called


### PR DESCRIPTION
## Description

### Update test_widget logic to make sense, half-removed only applies when upstream of blocker.
- This test was actually incorrect, to the best of my understanding.  Previously we inserted a fully-blocking valve upstream of a partially blocking ipimb, then asserted that the ipimb would be half-removed.  The lightpath logic actually expects this to be removed, and this only ever passed because it wasn't getting updated after the upstream valve was inserted.
- In the lightpath app we actually don't have proper callbacks for updating devices that aren't being inserted/removed.  Was it always this way? 🤷 
- looking at sim lightpath, imager (transmission=0.5, not blocking) after sequence of 
  - insert upstream blocker  -> insert im -> remove upstream blocker 
![image](https://github.com/user-attachments/assets/ab67d195-18df-4441-b75e-6709c56e1761)
  - insert im, with all other devices removed
![image](https://github.com/user-attachments/assets/3700dd53-54cf-49fe-9520-4decaf8b83c3)

### test_filter needed to wait for checkbox to update
- after way too many print statements, we were moving on before the value of the "removed" checkbox was ready to reflect the updated value.

## Motivation and Context
py3.12 tests were failing and I want them to pass.

My local testing showed this to be a bit of a race condition.  Lightpath tests were made before I truly understood all the ins and outs of qt testing, so there's probably a couple more places these tests can be tightened up.  Mostly it looks like we're not waiting for the right signals/slots to finish before our assertions.

## How Has This Been Tested?
Interactive testing, and hoping the CI bears it out

## Where Has This Been Documented?
This PR