### PR TITLE
BLD: drop support for python < 3.12, unpin networkx

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ exclude: |
 
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v6.0.0
     hooks:
     -   id: no-commit-to-branch
     -   id: trailing-whitespace
@@ -23,11 +23,11 @@ repos:
     -   id: debug-statements
 
 -   repo: https://github.com/pycqa/flake8.git
-    rev: 6.0.0
+    rev: 7.3.0
     hooks:
     -   id: flake8
 
 -   repo: https://github.com/timothycrosley/isort
-    rev: 5.11.5
+    rev: 8.0.0
     hooks:
     -   id: isort

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -18,13 +18,14 @@ build:
 
 requirements:
   build:
-    - python >=3.6
+    - python >=3.12
     - pip
     - setuptools_scm
   run:
-    - python >=3.6
+    - python >=3.12
     - coloredlogs
     - happi >=1.6.0
+    - networkx
     - numpy
     - ophyd
     - prettytable

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -42,6 +42,7 @@ test:
     - ipython
     - pytest
     - pytest-qt
+    - pytest-cov
 
 about:
   home: https://github.com/pcdshub/lightpath

--- a/lightpath/tests/test_gui.py
+++ b/lightpath/tests/test_gui.py
@@ -1,4 +1,4 @@
-from distutils.spawn import find_executable
+import shutil
 from unittest.mock import Mock
 
 import pytest
@@ -28,7 +28,7 @@ def test_app_buttons(lightapp: LightApp):
 
 def test_lightpath_launch_script():
     # Check that the executable was installed
-    assert find_executable('lightpath')
+    assert shutil.which('lightpath')
 
 
 def test_focus_on_device(lightapp: LightApp, monkeypatch):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description = "{{ cookiecutter.description }}"
 dynamic = [ "version", "readme", "dependencies", "optional-dependencies", "optional-dependencies",]
 keywords = []
 name = "lightpath"
-requires-python = ">=3.9"
+requires-python = ">=3.12"
 [[project.authors]]
 name = "SLAC National Accelerator Laboratory"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ coloredlogs
 happi>=1.6.0
 numpy
 ophyd
-networkx<3.3
+networkx
 prettytable


### PR DESCRIPTION
## Description
Officially drop py3.9 support, and unpin networkx in the process

## Motivation and Context
Looking over the new env, the solver ended up dropping to a lower version of networkx, and lightpath was the culprit.
Since we don't use py3.9 anymore, we may as well make it official

## How Has This Been Tested?
CI, really

## Where Has This Been Documented?
This PR